### PR TITLE
Fix: README adjusted to poky branch dora

### DIFF
--- a/README
+++ b/README
@@ -1,7 +1,7 @@
 This Layer depends on :
 URI: git://git.yoctoproject.org/poky
 URI: http://git.yoctoproject.org/git/poky
-Tag: dylan-9.0.1
+Tag: dora-10.0.0
 
 OpenEmbedded/Yocto layer for for Atmel AT91SAM SoC
 For now it supports:
@@ -16,9 +16,9 @@ Build procedure:
 1/ Clone yocto/poky git repository
 git clone git://git.yoctoproject.org/poky
 
-2/ Checkout dylan-9.0.1 tag
+2/ Checkout dora-10.0.0 tag
 cd poky
-git checkout dylan-9.0.1 -b my_branch
+git checkout dora-10.0.0 -b my_branch
 
 3/ Clone meta-atmel layer
 git clone http://github.com/linux4sam/meta-atmel


### PR DESCRIPTION
fd215d7c which forwards qt4-embedded to 4.8.5 depends on dora instead
of dylan. This should also be reflected in the READMEs build instructions.
