### PR TITLE
at91sam* fix DEFAULT_TUNE

### DIFF
--- a/conf/machine/at91sam9rlek.conf
+++ b/conf/machine/at91sam9rlek.conf
@@ -8,7 +8,6 @@ MACHINE_FEATURES = "kernel26 apm alsa ext2 ext3 usbgadget screen touchscreen ppp
 
 PREFERRED_PROVIDER_virtual/kernel = "linux-yocto-custom"
 
-DEFAULTTUNE = "arm926ejs"
 
 # used by sysvinit_2
 SERIAL_CONSOLE ?= "115200 ttyS0"

--- a/conf/machine/at91sam9x5ek.conf
+++ b/conf/machine/at91sam9x5ek.conf
@@ -13,7 +13,6 @@ KERNEL_DEVICETREE = "${S}/arch/arm/boot/dts/at91sam9g25ek.dts \
                      "
 PREFERRED_PROVIDER_virtual/kernel = "linux-yocto-custom"
 
-DEFAULTTUNE = "arm926ejs"
 
 # used by sysvinit_2
 SERIAL_CONSOLE ?= "115200 ttyS0"


### PR DESCRIPTION
Machines with an ARMv5TE class cpu are expected to produce packages with 'armv5te' as architecture, the current at91 configs break that by using 'arm926ejs' as architecture. This change has no performance impact is is purely there to unbreak DISTROs supporting multiple ARMv5TE machines.

This fixes issue #6

Signed-off-by: Koen Kooi koen@dominion.thruhere.net
