### PR TITLE
linux-yocto-custom: avoid PV going backwards on updates

### DIFF
--- a/recipes-kernel/linux/linux-yocto-custom_3.10.bbappend
+++ b/recipes-kernel/linux/linux-yocto-custom_3.10.bbappend
@@ -1,6 +1,6 @@
 KBRANCH = "linux-3.10-at91"
 SRCREV = "68f2c28207fbc081f7be75fc01aca4827aa4a9f1"
-PV = "${LINUX_VERSION}+${SRCREV}"
+PV = "${LINUX_VERSION}+${SRCPV}"
 
 PR = "r5"
 

--- a/recipes-kernel/linux/linux-yocto-custom_3.6.9.bb
+++ b/recipes-kernel/linux/linux-yocto-custom_3.6.9.bb
@@ -59,7 +59,7 @@ SRC_URI += "file://defconfig"
 # build a different release of the Linux kernel.
 # tag: v3.4 76e10d158efb6d4516018846f60c2ab5501900bc
 SRCREV="59134b04621dd73254d54cb67d9ffbf4f626dbc5"
-PV = "${LINUX_VERSION}+${SRCREV}"
+PV = "${LINUX_VERSION}+${SRCPV}"
 
 
 PR = "r1"


### PR DESCRIPTION
Using SRCREV instead of SRCPV in PV will lead to errors like:

```
ERROR: QA Issue: Package version for package kernel-module-lib80211-crypt-wep went backwards which would break package feeds from (0:3.10+ea25eb8a3ac9fcebc6c0d3b1c8e0c1223684d331-r4.1 to 0:3.10+68f2c28207fbc081f7be75fc01aca4827aa4a9f1-r5.1)
```

Which breaks upgrade paths.

Signed-off-by: Koen Kooi koen@dominion.thruhere.net
