### PR TITLE
sama5d3_xplained.conf: remove IMAGE_POSTPROCESS_COMMAND

### DIFF
--- a/conf/machine/sama5d3_xplained.conf
+++ b/conf/machine/sama5d3_xplained.conf
@@ -37,5 +37,3 @@ EXTRA_IMAGEDEPENDS += "at91bootstrap u-boot"
 
 module_autoload_atmel_usba_udc = "atmel_usba_udc"
 module_autoload_g_serial = "g_serial"
-
-ROOTFS_POSTPROCESS_COMMAND += "sama5d3_xplained_rootfs_postprocess; "


### PR DESCRIPTION
The method is only defined in the demo images, so trying to build any
other image will result in:

/build/v2013.12/build/tmp-angstrom_v2013_12-eglibc/work/sama5d3_xplained-angstrom-linux-gnueabi/systemd-image/1.0-r0/temp/run.do_rootfs.14199:
line 436: sama5d3_xplained_rootfs_postprocess: command not found

Signed-off-by: Koen Kooi koen@dominion.thruhere.net
