### PR TITLE
Update README to properly reference dependencies

### DIFF
--- a/README
+++ b/README
@@ -1,8 +1,8 @@
 This Layer depends on :
-- Poky
-URI: git://git.yoctoproject.org/poky
-URI: http://git.yoctoproject.org/git/poky
-Tag: dora-10.0.1
+- OpenEmbedded-core
+URI: git://git.openembedded.org/openembedded-core
+URI: http://cgit.openembedded.orgopenembedded-core/
+Branch: dora
 
 - meta-openembedded
 URI: git://git.openembedded.org/meta-openembedded


### PR DESCRIPTION
OE layers depend on upstream OE layers, not downstream distro forks of the layers.

The instructions still reference poky, but since they don't work anyway due to other bugs in this layer I've left them alone.

Signed-off-by: Koen Kooi koen@dominion.thruhere.net
