### PR TITLE
Changed u-boot settings for sama5d3_xplained.conf

### DIFF
--- a/conf/machine/sama5d3_xplained.conf
+++ b/conf/machine/sama5d3_xplained.conf
@@ -31,7 +31,7 @@ UBINIZE_ARGS = " -m 0x800 -p 0x20000 -s 2048"
 
 UBI_VOLNAME = "rootfs"
 
-UBOOT_MACHINE = "${MACHINE}_nandflash_config"
+UBOOT_MACHINE = "sama5d3xek_nandflash_config"
 UBOOT_ENTRYPOINT = "0x20008000"
 UBOOT_LOADADDRESS = "0x20008000"
 


### PR DESCRIPTION
sama5d3_xplained uses the same config as sama5d3xek and there is no explicit sama5d3_xplained_nandflash_config
UBOOT_MACHINE = "sama5d3xek_nandflash_config"

Signed-off-by: Marco Cavallini m.cavallini@koansoftware.com
