### PR TITLE
Update atmel-demo-image.inc

### DIFF
--- a/recipes-core/images/atmel-demo-image.inc
+++ b/recipes-core/images/atmel-demo-image.inc
@@ -36,10 +36,6 @@ inherit core-image
 # we don't need the kernel in the image
 ROOTFS_POSTPROCESS_COMMAND += "rm -f ${IMAGE_ROOTFS}/boot/*Image*; "
 
-# Unified usba_udc and g_serial
-module_autoload_atmel_usba_udc = "atmel_usba_udc"
-module_autoload_g_serial = "g_serial"
-
 sama5d3_xplained_rootfs_postprocess() {
     curdir=$PWD
     cd ${IMAGE_ROOTFS}


### PR DESCRIPTION
module_autoload is used by the kernel packaging bbclass, so it needs to be visible in that scope (the kernel recipe itself or the machine.conf)
Credit to: Koen Kooi
