### PR TITLE
v4l-utils: Fix S!=B failure

### DIFF
--- a/recipes-multimedia/v4l2apps/v4l-utils_0.8.8.bb
+++ b/recipes-multimedia/v4l2apps/v4l-utils_0.8.8.bb
@@ -7,7 +7,7 @@ PR = "r2"
 
 DEPENDS = "jpeg"
 
-inherit autotools gettext
+inherit autotools-brokensep gettext
 
 # libv4l was absorbed into this, let OE know that
 PROVIDES = "libv4l"


### PR DESCRIPTION
Without the change, fails in do_configure because autoreconf cannot find configure.ac

Signed-of-by: Tim Orling TicoTimo@gmail.com
