### PR TITLE
Fix bootloader selection

### DIFF
--- a/conf/machine/include/bootloaders.inc
+++ b/conf/machine/include/bootloaders.inc
@@ -1,2 +1,2 @@
 # Add bootloaders to the images of every machine
-EXTRA_IMAGEDEPENDS += "at91bootstrap u-boot"
+EXTRA_IMAGEDEPENDS += "at91bootstrap virtual/bootloader"


### PR DESCRIPTION
After the at91 u-boot recipes have been namespace we need to stop asking for 'u-boot' since that will fail to build if it pick a u-boot.bb recipe from another layer:

ERROR: Logfile of failure stored in: /build/jenkins/angstrom-v2013.12/machine/sama5d3_xplained/build/tmp-angstrom_v2013_12-eglibc/work/sama5d3_xplained-angstrom-linux-gnueabi/u-boot/2013.01.01-r1/temp/log.do_compile.18796
Log data follows:
| DEBUG: Executing shell function do_compile
| NOTE: make -j8 CROSS_COMPILE=arm-angstrom-linux-gnueabi- CC=arm-angstrom-linux-gnueabi-gcc  --sysroot=/build/jenkins/angstrom-v2013.12/machine/sama5d3_xplained/build/tmp-angstrom_v2013_12-eglibc/sysroots/sama5d3_xplained sama5d3xek_nandflash_config
| make: **\* No rule to make target `sama5d3xek_nandflash_config'.  Stop.
| make: **\* [sama5d3xek_nandflash_config] Error 1
| ERROR: oe_runmake failed
| WARNING: /build/jenkins/angstrom-v2013.12/machine/sama5d3_xplained/build/tmp-angstrom_v2013_12-eglibc/work/sama5d3_xplained-angstrom-linux-gnueabi/u-boot/2013.01.01-r1/temp/run.do_compile.18796:1 exit 1 from
|   exit 1
| ERROR: Function failed: do_compile (log file is located at /build/jenkins/angstrom-v2013.12/machine/sama5d3_xplained/build/tmp-angstrom_v2013_12-eglibc/work/sama5d3_xplained-angstrom-linux-gnueabi/u-boot/2013.01.01-r1/temp/log.do_compile.18796)
NOTE: recipe u-boot-2013.01.01-r1: task do_compile: Failed
ERROR: Task 134 (/build/jenkins/angstrom-v2013.12/machine/sama5d3_xplained/sources/meta-ti/recipes-bsp/u-boot/u-boot_2013.01.01.bb, do_compile) failed with exit code '1'
NOTE: recipe systemd-image-1.0-r0: task do_rootfs: Started
NOTE: recipe systemd-image-1.0-r0: task do_rootfs: Succeeded
NOTE: Tasks Summary: Attempted 2943 tasks of which 2313 didn't need to be rerun and 1 failed.
NOTE: Writing buildhistory

Summary: 1 task failed:
  /build/jenkins/angstrom-v2013.12/machine/sama5d3_xplained/sources/meta-ti/recipes-bsp/u-boot/u-boot_2013.01.01.bb, do_compile

Signed-off-by: Koen Kooi koen@dominion.thruhere.net
