### PR TITLE
u-boot-at91 2013.07: soft-assign variables

### DIFF
--- a/recipes-bsp/u-boot/u-boot-at91_2013.07.bb
+++ b/recipes-bsp/u-boot/u-boot-at91_2013.07.bb
@@ -20,9 +20,9 @@ COMPATIBLE_MACHINE = "(sama5d3xek|at91sam9x5ek|sama5d3_xplained)"
 # To build u-boot for your machine, provide the following lines in
 # your machine config, replacing the assignments as appropriate for
 # your machine.
-UBOOT_MACHINE_${MACHINE} = "${MACHINE}_nandflash_config"
-UBOOT_ENTRYPOINT = "0x20002000"
-UBOOT_LOADADDRESS = "0x20002000"
+UBOOT_MACHINE ?= "${MACHINE}_nandflash_config"
+UBOOT_ENTRYPOINT ?= "0x20002000"
+UBOOT_LOADADDRESS ?= "0x20002000"
 
 SRC_URI = "git://github.com/linux4sam/u-boot-at91.git;branch=u-boot-2013.07-at91;protocol=git"
 S = "${WORKDIR}/git"


### PR DESCRIPTION
This stops the recipe from overwriting the values set in MACHINE.conf.

Signed-off-by: Koen Kooi koen@dominion.thruhereu.net
