### PR TITLE
at91bootstrap 3.6.2: fix build with OE-core master

### DIFF
--- a/recipes-bsp/at91bootstrap/at91bootstrap_3.6.2.bb
+++ b/recipes-bsp/at91bootstrap/at91bootstrap_3.6.2.bb
@@ -9,7 +9,9 @@ SRCREV="1e8fd41ce7149f7d2063a3b3bcf2c69e77b97732"
 
 PR = "r1"
 
-SRC_URI = "git://github.com/linux4sam/at91bootstrap.git;protocol=git"
+SRC_URI = "git://github.com/linux4sam/at91bootstrap.git;protocol=git \
+           file://bfa42af7a2c21bada264214d2dd209edc64eb041.patch \
+          "
 
 S = "${WORKDIR}/git"
 

--- a/recipes-bsp/at91bootstrap/files/bfa42af7a2c21bada264214d2dd209edc64eb041.patch
+++ b/recipes-bsp/at91bootstrap/files/bfa42af7a2c21bada264214d2dd209edc64eb041.patch
@@ -1,0 +1,61 @@
+From bfa42af7a2c21bada264214d2dd209edc64eb041 Mon Sep 17 00:00:00 2001
+From: Mathieu Anquetin <mathieu.anquetin@groupe-cahors.com>
+Date: Thu, 12 Dec 2013 11:57:27 +0100
+Subject: [PATCH] Remove standard includes
+
+These includes are not needed and fail the build when using a custom
+built toolchain from OpenEmbedded.
+
+Signed-off-by: Mathieu Anquetin <mathieu.anquetin@groupe-cahors.com>
+---
+
+From https://github.com/linux4sam/at91bootstrap/commit/bfa42af7a2c21bada264214d2dd209edc64eb041
+
+ Makefile       | 4 +++-
+ driver/debug.c | 1 -
+ driver/flash.c | 2 --
+ 3 files changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index fc5d593..f061c21 100644
+--- a/Makefile
++++ b/Makefile
+@@ -191,7 +191,9 @@ OBJS:= $(SOBJS-y) $(COBJS-y)
+ INCL=board/$(BOARD)
+ GC_SECTIONS=--gc-sections
+ 
+-CPPFLAGS=-ffunction-sections -g -Os -Wall \
++NOSTDINC_FLAGS=-nostdinc -isystem $(shell $(CC) -print-file-name=include)
++
++CPPFLAGS=$(NOSTDINC_FLAGS) -ffunction-sections -g -Os -Wall \
+ 	-fno-stack-protector \
+ 	-I$(INCL) -Iinclude -Ifs/include \
+ 	-DAT91BOOTSTRAP_VERSION=\"$(VERSION)$(REV)$(SCMINFO)\" -DCOMPILE_TIME="\"$(DATE)\""
+diff --git a/driver/debug.c b/driver/debug.c
+index cb4fd44..8a962af 100644
+--- a/driver/debug.c
++++ b/driver/debug.c
+@@ -27,7 +27,6 @@
+  */
+ #include "usart.h"
+ #include "debug.h"
+-#include <stdio.h>
+ #include <stdarg.h>
+ 
+ #define MAX_BUFFER	128
+diff --git a/driver/flash.c b/driver/flash.c
+index 11615c7..ebc5d5a 100644
+--- a/driver/flash.c
++++ b/driver/flash.c
+@@ -26,8 +26,6 @@
+ #include "../include/part.h"
+ #include "../include/main.h"
+ #include "../include/flash.h"
+-#include <stdlib.h>
+-
+ 
+ int load_norflash(unsigned int img_addr,
+ 		unsigned int img_size,
+-- 
+2.0.3
+


### PR DESCRIPTION
Patch was backported from upstream at91bootstrap.

Signed-off-by: Koen Kooi koen@dominion.thruhere.net
