### PR TITLE
Fix building kernel for sama5d3xek and sama5d3 xplained

### DIFF
--- a/conf/machine/include/bootloaders.inc
+++ b/conf/machine/include/bootloaders.inc
@@ -1,2 +1,3 @@
 # Add bootloaders to the images of every machine
 EXTRA_IMAGEDEPENDS += "at91bootstrap virtual/bootloader"
+KERNEL_IMAGETYPE = "uImage"

--- a/recipes-kernel/linux/linux-yocto-custom_3.10.bb
+++ b/recipes-kernel/linux/linux-yocto-custom_3.10.bb
@@ -43,7 +43,7 @@
 
 # Override SRC_URI in a bbappend file to point at a different source
 # tree if you do not want to build from Linus' tree.
-SRC_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git;protocol=git;nocheckout=1"
+SRC_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git;protocol=git;nocheckout=1;name=machine"
 
 LINUX_VERSION ?= "3.10"
 LINUX_VERSION_EXTENSION ?= "-custom"
@@ -54,7 +54,7 @@ require recipes-kernel/linux/linux-yocto.inc
 # Override SRCREV to point to a different commit in a bbappend file to
 # build a different release of the Linux kernel.
 # tag: v3.10 8bb495e3f02401ee6f76d1b1d77f3ac9f079e376"
-SRCREV = "8bb495e3f02401ee6f76d1b1d77f3ac9f079e376"
+SRCREV_machine = "8bb495e3f02401ee6f76d1b1d77f3ac9f079e376"
 
 PR = "r1"
 PV = "${LINUX_VERSION}+git${SRCPV}"

--- a/recipes-kernel/linux/linux-yocto-custom_3.10.bbappend
+++ b/recipes-kernel/linux/linux-yocto-custom_3.10.bbappend
@@ -1,5 +1,5 @@
 KBRANCH = "linux-3.10-at91"
-SRCREV = "35158dd80a94df2b71484b9ffa6e642378209156"
+SRCREV_machine = "${AUTOREV}"
 PV = "${LINUX_VERSION}+${SRCPV}"
 
 DEPENDS += "dtc-native"

--- a/recipes-kernel/linux/linux-yocto-custom_3.10.bbappend
+++ b/recipes-kernel/linux/linux-yocto-custom_3.10.bbappend
@@ -12,6 +12,8 @@ SRC_URI = "git://github.com/linux4sam/linux-at91.git;protocol=git;branch=${KBRAN
 SRC_URI += "file://defconfig"
 
 SRCREV_machine_sama5d4-xplained = "46f4253693b0ee8d25214e7ca0dde52e788ffe95"
+SRCREV_machine_sama5d3xek = "25ce4e2fcdffcf271e1f92788dee1340285dc251"
+SRCREV_machine_sama5d3-xplained = "25ce4e2fcdffcf271e1f92788dee1340285dc251"
 
 do_deploy_append() {
 	if [ ${UBOOT_FIT_IMAGE} = "xyes" ]; then

--- a/recipes-kernel/linux/linux-yocto-custom_3.10.bbappend
+++ b/recipes-kernel/linux/linux-yocto-custom_3.10.bbappend
@@ -2,6 +2,8 @@ KBRANCH = "linux-3.10-at91"
 SRCREV = "35158dd80a94df2b71484b9ffa6e642378209156"
 PV = "${LINUX_VERSION}+${SRCPV}"
 
+DEPENDS += "dtc-native"
+
 PR = "r5"
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/files/${MACHINE}:"

--- a/recipes-kernel/linux/linux-yocto-custom_3.10.bbappend
+++ b/recipes-kernel/linux/linux-yocto-custom_3.10.bbappend
@@ -8,10 +8,10 @@ PR = "r5"
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/files/${MACHINE}:"
 
-SRC_URI = "git://github.com/linux4sam/linux-at91.git;protocol=git;branch=${KBRANCH};nocheckout=1"
+SRC_URI = "git://github.com/linux4sam/linux-at91.git;protocol=git;branch=${KBRANCH};nocheckout=1;name=machine"
 SRC_URI += "file://defconfig"
 
-SRCREV_sama5d4-xplained = "46f4253693b0ee8d25214e7ca0dde52e788ffe95"
+SRCREV_machine_sama5d4-xplained = "46f4253693b0ee8d25214e7ca0dde52e788ffe95"
 
 do_deploy_append() {
 	if [ ${UBOOT_FIT_IMAGE} = "xyes" ]; then

--- a/recipes-kernel/linux/linux-yocto-custom_3.10.bbappend
+++ b/recipes-kernel/linux/linux-yocto-custom_3.10.bbappend
@@ -16,7 +16,7 @@ SRCREV_machine_sama5d3xek = "25ce4e2fcdffcf271e1f92788dee1340285dc251"
 SRCREV_machine_sama5d3-xplained = "25ce4e2fcdffcf271e1f92788dee1340285dc251"
 
 do_deploy_append() {
-	if [ ${UBOOT_FIT_IMAGE} = "xyes" ]; then
+	if [ "${UBOOT_FIT_IMAGE}" = "xyes" ]; then
 		DTB_PATH="${B}/arch/${ARCH}/boot/dts/"
 		if [ ! -e "${DTB_PATH}" ]; then
 			DTB_PATH="${B}/arch/${ARCH}/boot/"


### PR DESCRIPTION
This patchset adresses some problems I found while using meta-atmel for the first time. By following verbatim the instructions in README I came up with broken build for kernel recipe, which this patches solve, at least in my environment. Please help in reviewing them.

Issues belong to either of:
* dependencies on tools which are not explicitly handled by metadata in meta-atmel, relying on them being installed on the host build system
* the commit pointed to by the current kernel recipe (linux-yocto-custom_3.10) is broken at least for sama5d3{-xplained|xek} machines

Both issues were already discussed on the forum at the following links, but no solution was publicly provided:
* http://www.at91.com/discussions/viewtopic.php/f,12/t,22461.html
* http://www.at91.com/discussions/viewtopic.php/t,23774.html

Patches were designed to minimize the impact of the changes on current tree and to ensure that:
* no additional dependencies need to be satisfied outside of Yocto
* linux-yocto-custom_3.10 kernel recipe should be AUTOREV by default (I asked if so on #at91) but allow to pin SRCREV for specific machines that require to