### PR TITLE
linux-yocto-custom_3.10: add missing quotes (re-apply)

### DIFF
--- a/recipes-kernel/linux/linux-yocto-custom_3.10.bb
+++ b/recipes-kernel/linux/linux-yocto-custom_3.10.bb
@@ -20,7 +20,7 @@ SRC_URI = "git://github.com/linux4sam/linux-at91.git;protocol=git;branch=${KBRAN
 SRC_URI += "file://defconfig"
 
 do_deploy_append() {
-	if [ ${UBOOT_FIT_IMAGE} = "xyes" ]; then
+	if [ "${UBOOT_FIT_IMAGE}" = "xyes" ]; then
 		DTB_PATH="${B}/arch/${ARCH}/boot/dts/"
 		if [ ! -e "${DTB_PATH}" ]; then
 			DTB_PATH="${B}/arch/${ARCH}/boot/"


### PR DESCRIPTION
* fixes "[: =: unexpected operator" error in log.do_deploy when
${UBOOT_FIT_IMAGE} is not set
* already applied in 2f5e00b2456d0e5e7ff0078f1f4de1620b3f1bbb but
then lost while removing bbappends