### PR TITLE
add missing dependencies when UBOOT_FIT_IMAGE is set

### DIFF
--- a/recipes-kernel/linux/linux-yocto-custom_3.10.bb
+++ b/recipes-kernel/linux/linux-yocto-custom_3.10.bb
@@ -19,6 +19,11 @@ KBRANCH = "linux-3.10-at91"
 SRC_URI = "git://github.com/linux4sam/linux-at91.git;protocol=git;branch=${KBRANCH};nocheckout=1"
 SRC_URI += "file://defconfig"
 
+python __anonymous () {
+  if d.getVar('UBOOT_FIT_IMAGE', True) == 'xyes':
+    d.appendVar('DEPENDS', ' u-boot-mkimage-native dtc-native')
+}
+
 do_deploy_append() {
 	if [ ${UBOOT_FIT_IMAGE} = "xyes" ]; then
 		DTB_PATH="${B}/arch/${ARCH}/boot/dts/"


### PR DESCRIPTION
This is a rework of my previous patch that was reviewed by @alexandrebelloni in #37. This conditionally adds dependencies only when needed and without forcing KERNEL_IMAGETYPE value to "uImage"  

* do_deploy_append() conditionally requires mkimage from u-boot-mkimage-native
when UBOOT_FIT_IMAGE is enabled. mkimage in turn depends on dtc
* use a python anonymous function to conditionally append them to DEPENDS
* fixes errors discussed in [1] when these tools are not installed on the host
machine. Recipes dependencies should be handled by the metadata instead of
relying on host tools.

[1] http://www.at91.com/discussions/viewtopic.php/f,12/t,22461.html