### PR TITLE
graphics: mesa gallium package

### DIFF
--- a/recipes-graphics/mesa/mesa_%.bbappend
+++ b/recipes-graphics/mesa/mesa_%.bbappend
@@ -1,0 +1,3 @@
+PACKAGECONFIG_append = "gallium"
+PACKAGECONFIG_append =" gallium-egl  "
+PACKAGECONFIG_append =" gallium-gbm  "


### PR DESCRIPTION
Can be used as fallback opengl implementation since no GPU is present

Check video demos at :
https://dockr.eurogiciel.fr/blogs/embedded/qtwayland-sama5d4-xplained/


Change-Id: I670bd4d7a8ae63664ac19c3e61966db27f1d180f
Signed-off-by: Philippe Coval <philippe.coval@open.eurogiciel.org>