### PR TITLE
u-boot-at91 git: change u-boot include name

### DIFF
--- a/recipes-bsp/u-boot/u-boot-at91_git.bb
+++ b/recipes-bsp/u-boot/u-boot-at91_git.bb
@@ -1,4 +1,4 @@
-require u-boot.inc
+require u-boot-atmel.inc
 
 DEFAULT_PREFERENCE = "-1"
 


### PR DESCRIPTION
When backporting the u-boot namespace fix this recipe was missed.

Signed-off-by: Koen Kooi <koen@dominion.thruhere.net>