### PR TITLE
linux firmware: install all wilc100* firmware files

### DIFF
--- a/recipes-kernel/linux/atmel-wireless-firmware_git.bb
+++ b/recipes-kernel/linux/atmel-wireless-firmware_git.bb
@@ -27,6 +27,6 @@ do_install() {
 
 
 FILES_${PN} = " \
-  /lib/firmware/atmel/wilc1000_*.bin \
+  /lib/firmware/atmel/wilc100*_*.bin \
 "
 # TODO: use ALTERNATIVE like in "linux-firmware" package


### PR DESCRIPTION
without it will fail to install and complain with a message like :
  /lib/firmware/atmel/wilc1003_firmware.bin [installed-vs-shipped]

Change-Id: I3bb5ef10d4c4229fd15bca57557a7dc5c6c4e204
Signed-off-by: Philippe Coval <rzr@gna.org>