### PR TITLE
machine: sama5d2/4-xplained-*: Fix dependencies errors

### DIFF
--- a/conf/machine/sama5d2-xplained-sd.conf
+++ b/conf/machine/sama5d2-xplained-sd.conf
@@ -26,3 +26,6 @@ UBOOT_ENTRYPOINT = "0x20008000"
 UBOOT_LOADADDRESS = "0x20008000"
 
 AT91BOOTSTRAP_MACHINE ?= "sama5d2_xplained"
+
+# Needed for wic
+EXTRA_IMAGEDEPENDS += "dosfstools-native mtools-native"

--- a/conf/machine/sama5d2-xplained.conf
+++ b/conf/machine/sama5d2-xplained.conf
@@ -20,3 +20,6 @@ UBOOT_ENTRYPOINT = "0x20008000"
 UBOOT_LOADADDRESS = "0x20008000"
 
 AT91BOOTSTRAP_MACHINE ?= "sama5d2_xplained"
+
+# Needed for wic
+EXTRA_IMAGEDEPENDS += "dosfstools-native mtools-native"

--- a/conf/machine/sama5d4-xplained-sd.conf
+++ b/conf/machine/sama5d4-xplained-sd.conf
@@ -30,3 +30,6 @@ UBOOT_ENTRYPOINT = "0x20008000"
 UBOOT_LOADADDRESS = "0x20008000"
 
 AT91BOOTSTRAP_MACHINE ?= "sama5d4_xplained"
+
+# Needed for wic
+EXTRA_IMAGEDEPENDS += "dosfstools-native mtools-native"


### PR DESCRIPTION
Hi,

The current commit fixes the dependencies errors with dosfstools-native and mtools-native
on sama5d2-xplained, sama5d2-xplained-sd and sama5d4-xplained-sd machines.

Best regards,

Mylène Josserand