### PR TITLE
qtbase-fonts, mxt-app and sama5d2/4-xplained-* errors fixed

### DIFF
--- a/conf/machine/sama5d2-xplained-sd.conf
+++ b/conf/machine/sama5d2-xplained-sd.conf
@@ -26,3 +26,6 @@ UBOOT_ENTRYPOINT = "0x20008000"
 UBOOT_LOADADDRESS = "0x20008000"
 
 AT91BOOTSTRAP_MACHINE ?= "sama5d2_xplained"
+
+# Needed for wic
+EXTRA_IMAGEDEPENDS += "dosfstools-native mtools-native"

--- a/conf/machine/sama5d2-xplained.conf
+++ b/conf/machine/sama5d2-xplained.conf
@@ -20,3 +20,6 @@ UBOOT_ENTRYPOINT = "0x20008000"
 UBOOT_LOADADDRESS = "0x20008000"
 
 AT91BOOTSTRAP_MACHINE ?= "sama5d2_xplained"
+
+# Needed for wic
+EXTRA_IMAGEDEPENDS += "dosfstools-native mtools-native"

--- a/conf/machine/sama5d4-xplained-sd.conf
+++ b/conf/machine/sama5d4-xplained-sd.conf
@@ -30,3 +30,6 @@ UBOOT_ENTRYPOINT = "0x20008000"
 UBOOT_LOADADDRESS = "0x20008000"
 
 AT91BOOTSTRAP_MACHINE ?= "sama5d4_xplained"
+
+# Needed for wic
+EXTRA_IMAGEDEPENDS += "dosfstools-native mtools-native"

--- a/qt5-layer/recipes-qt/images/atmel-qt5-demo-image.bb
+++ b/qt5-layer/recipes-qt/images/atmel-qt5-demo-image.bb
@@ -54,7 +54,6 @@ IMAGE_INSTALL += "\
 	${CORE_IMAGE_BASE_INSTALL} \
 	\
 	qtbase \
-	qtbase-fonts \
 	qtbase-plugins \
 	qtbase-tools \
 	qtmultimedia \

--- a/recipes-utils/mxt-app/mxt-app/0001-fix-ret-type-in-read_boolean_file.patch
+++ b/recipes-utils/mxt-app/mxt-app/0001-fix-ret-type-in-read_boolean_file.patch
@@ -1,0 +1,26 @@
+From e957c0522770258b9b6d7eb4a96428fb29e6afdb Mon Sep 17 00:00:00 2001
+From: Alexandre Belloni <alexandre.belloni@free-electrons.com>
+Date: Wed, 10 Aug 2016 16:46:55 +0200
+Subject: [PATCH] Fix ret type in read_boolean_file
+
+ret is boolean so the comparison (ret < 0) will always evaluate to false.
+Change it to the proper type, int
+
+Signed-off-by: Alexandre Belloni <alexandre.belloni@free-electrons.com>
+---
+ src/libmaxtouch/sysfs/sysfs_device.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/libmaxtouch/sysfs/sysfs_device.c b/src/libmaxtouch/sysfs/sysfs_device.c
+index 6c01f02..5f562ef 100644
+--- a/src/libmaxtouch/sysfs/sysfs_device.c
++++ b/src/libmaxtouch/sysfs/sysfs_device.c
+@@ -483,7 +483,7 @@ static int read_boolean_file(struct mxt_device *mxt, char *filename,
+ {
+   FILE *file;
+   char val;
+-  bool ret;
++  int ret;
+ 
+   file = fopen(filename, "r");
+   if (!file) {

--- a/recipes-utils/mxt-app/mxt-app_git.bb
+++ b/recipes-utils/mxt-app/mxt-app_git.bb
@@ -12,6 +12,7 @@ PV = "1.27+git${SRCPV}"
 inherit autotools
 
 SRCREV="84665a7b7013285b9f3ee799ee1d9ca7bc6f0e55"
-SRC_URI = "git://github.com/atmel-maxtouch/mxt-app.git"
+SRC_URI = "git://github.com/atmel-maxtouch/mxt-app.git \
+	file://0001-fix-ret-type-in-read_boolean_file.patch"
 
 S = "${WORKDIR}/git"

--- a/recipes-utils/mxt-app/mxt-app_git.bb
+++ b/recipes-utils/mxt-app/mxt-app_git.bb
@@ -7,10 +7,11 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=8b6acde4490765c7b838377ac61e2d2d"
 DEPENDS = "libusb1"
 
 PR = "r0"
+PV = "1.27+git${SRCPV}"
 
 inherit autotools
 
-SRCREV="f0da763cc8ea78dc12915d59bc5fab20cd1cec06"
+SRCREV="84665a7b7013285b9f3ee799ee1d9ca7bc6f0e55"
 SRC_URI = "git://github.com/atmel-maxtouch/mxt-app.git"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Hi,

Here is a summary of what these commits handle:
- Fix an error about "qtbase-fonts" package on "atmel-qt5-demo-image"
- Bump mxt-app to version 1.27
- Add a patch on mxt-app to fix gcc6 errors (see PR#53 on upstream project)
- Fix dependencies errors on sama5d2/4-xplained-* machines

Best regards,
Mylène Josserand