### PR TITLE
conf: machine: *-sd: add wic dependency on do_deploy of u-boot-at91

### DIFF
--- a/conf/machine/at91sam9x5ek-sd.conf
+++ b/conf/machine/at91sam9x5ek-sd.conf
@@ -14,6 +14,7 @@ KERNEL_DEVICETREE = "at91sam9g15ek.dtb \
 
 IMAGE_FSTYPES += " tar.gz wic"
 
+do_image_wic[depends] += "u-boot-at91:do_deploy"
 WKS_FILE = "sdimage-bootpart.wks"
 IMAGE_BOOT_FILES = "BOOT.BIN u-boot.bin zImage \
 	zImage-at91sam9g15ek.dtb;at91sam9g15ek.dtb \

--- a/conf/machine/sama5d2-xplained-sd.conf
+++ b/conf/machine/sama5d2-xplained-sd.conf
@@ -13,6 +13,7 @@ KERNEL_DEVICETREE = " \
 		"
 IMAGE_FSTYPES += " tar.gz wic"
 
+do_image_wic[depends] += "u-boot-at91:do_deploy"
 WKS_FILE = "sdimage-bootpart.wks"
 IMAGE_BOOT_FILES = "BOOT.BIN u-boot.bin zImage \
 	zImage-at91-sama5d2_xplained.dtb;at91-sama5d2_xplained.dtb \

--- a/conf/machine/sama5d27-som1-ek-sd.conf
+++ b/conf/machine/sama5d27-som1-ek-sd.conf
@@ -12,6 +12,7 @@ KERNEL_DEVICETREE = " \
 		at91-sama5d27_som1_ek_pda7b.dtb \
 		"
 
+do_image_wic[depends] += "u-boot-at91:do_deploy"
 IMAGE_FSTYPES += " tar.gz wic"
 WKS_FILE = "sdimage-bootpart.wks"
 IMAGE_BOOT_FILES = "BOOT.BIN u-boot.bin zImage \

--- a/conf/machine/sama5d3-xplained-sd.conf
+++ b/conf/machine/sama5d3-xplained-sd.conf
@@ -13,6 +13,7 @@ KERNEL_DEVICETREE = " \
 		"
 IMAGE_FSTYPES += " tar.gz wic"
 
+do_image_wic[depends] += "u-boot-at91:do_deploy"
 WKS_FILE = "sdimage-bootpart.wks"
 IMAGE_BOOT_FILES = "BOOT.BIN u-boot.bin zImage \
 	zImage-at91-sama5d3_xplained.dtb;at91-sama5d3_xplained.dtb \

--- a/conf/machine/sama5d4-xplained-sd.conf
+++ b/conf/machine/sama5d4-xplained-sd.conf
@@ -15,6 +15,7 @@ KERNEL_DEVICETREE = " \
 
 IMAGE_FSTYPES += " tar.gz wic"
 
+do_image_wic[depends] += "u-boot-at91:do_deploy"
 WKS_FILE = "sdimage-bootpart.wks"
 IMAGE_BOOT_FILES = "BOOT.BIN u-boot.bin zImage \
 	zImage-at91-sama5d4_xplained.dtb;at91-sama5d4_xplained.dtb \


### PR DESCRIPTION
This fixes the wic image not being updated when the bootloader binaries
would be updated.

Add a dependency to do_deploy of u-boot-at91 to do_image_wic so that the
image is updated when needed.

Signed-off-by: Quentin Schulz <quentin.schulz@free-electrons.com>