### PR TITLE
linux-at91_4.9: Fix RDEPENDS key replacement

### DIFF
--- a/recipes-kernel/linux/linux-at91_4.9.bb
+++ b/recipes-kernel/linux/linux-at91_4.9.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=d7810fab7487fb0aad327b76f1be7cd7"
 
 inherit kernel
 
-RDEPENDS_kernel-base=""
+RDEPENDS_${KERNEL_PACKAGE_NAME}-base = ""
 FILESEXTRAPATHS_prepend := "${THISDIR}/${P}:"
 
 PV = "4.9+git${SRCPV}"


### PR DESCRIPTION
Same change as commit 54d1a28, applied to the 4.9 kernel recipe.