### PR TITLE
Fix u-boot environment address and mtdparts in nandflash.tcl script

### DIFF
--- a/scripts/nandflash.tcl
+++ b/scripts/nandflash.tcl
@@ -285,7 +285,7 @@ if {! [file exists $rootfsFile]} {
 ## NandFlash Mapping
 set bootStrapAddr	0x00000000
 set ubootAddr		0x00040000
-set ubootEnvAddr	0x000c0000
+set ubootEnvAddr	0x00140000
 set dtbAddr		0x00180000
 set kernelAddr		0x00200000
 set rootfsAddr		0x00800000
@@ -306,7 +306,7 @@ lappend u_boot_variables \
     "stdin=serial" \
     "stdout=serial" \
     "stderr=serial" \
-    "bootargs=console=ttyS0,115200 mtdparts=atmel_nand:256k(bootstrap)ro,512k(uboot)ro,256k(env),256k(env_redundant),256k(spare),512k(dtb),6M(kernel)ro,-(rootfs) rootfstype=ubifs ubi.mtd=7 root=ubi0:rootfs rw $videoMode" \
+    "bootargs=console=ttyS0,115200 mtdparts=atmel_nand:256k(bootstrap)ro,512k(uboot)ro,256k(spare),256k(env_redundant),256k(env),512k(dtb),6M(kernel)ro,-(rootfs) rootfstype=ubifs ubi.mtd=7 root=ubi0:rootfs rw $videoMode" \
     "$bootCmd"
 
 ## Additional files to load


### PR DESCRIPTION
Hi,

This commit fixes u-boot environment address and mtdparts in nandflash.tcl script to match the configs of sam9 and sama5 in u-boot-at91.

Previously, the script uses old address for u-boot environment (0x000C0000) that has now been moved to 0x00140000 since commit [4744f870b23d7f84d13aa767835b3a457e34e181](https://github.com/linux4sam/u-boot-at91/commit/4744f870b23d7f84d13aa767835b3a457e34e181). As u-boot-env is not initialized, u-boot is detecting a CRC error and is using its default values (related to jffs2). As it doesn't match generated image, boot sequence is interrupted.

I was only able to test it on at91sam9g45ekes board and it is properly booting.

Regards