### PR TITLE
distro: Fix syslog update-alternatives issue

### DIFF
--- a/conf/distro/poky-atmel.conf
+++ b/conf/distro/poky-atmel.conf
@@ -25,3 +25,5 @@ ALLOW_EMPTY_qtwebsockets-qmlplugins = "1"
 
 EXTRA_OECONF_remove = "${DISABLE_STATIC}"
 PREFERRED_VERSION_swig = "3.0.8"
+
+VIRTUAL-RUNTIME_syslog = "busybox-syslog"


### PR DESCRIPTION
Hello,

Here is a commit to fix the issue on sumo's branch about update-alternatives of klogd.
The warning shown was:

WARNING: atmel-xplained-demo-image-1.0-r1 do_rootfs: busybox.postinst
    returned 1, marking as unpacked only, configuration required on target.
    WARNING: atmel-xplained-demo-image-1.0-r1 do_rootfs: Intentionally
    failing postinstall scriptlets of ['busybox'] to defer them to first
    boot is deprecated. Please place them into pkg_postinst_ontarget_${PN} ().
    If deferring to first boot wasn't the intent, then scriptlet failure may
    mean an issue in the recipe, or a regression elsewhere.
    Details of the failure are in /home/mylene/yocto/build_atmel/tmp/work/\
    sama5d4_xplained_sd-poky-linux-gnueabi/atmel-xplained-demo-image/1.0-r1/temp/log.do_rootfs.

See the commit log for more details about the fix.

Thank you in advance,
Mylène

