### PR TITLE
machine: sama5: Add preferred provider for u-boot

### DIFF
--- a/conf/machine/include/sama5.inc
+++ b/conf/machine/include/sama5.inc
@@ -7,6 +7,7 @@ SOC_FAMILY = "sama5"
 
 PREFERRED_PROVIDER_virtual/kernel_sama5 ?= "linux-at91"
 PREFERRED_PROVIDER_virtual/bootloader_sama5 ?= "u-boot-at91"
+PREFERRED_PROVIDER_u-boot_sama5 ?= "u-boot-at91"
 
 PREFERRED_PROVIDER_jpeg ?= "jpeg"
 PREFERRED_PROVIDER_jpeg-native ?= "jpeg-native"


### PR DESCRIPTION
Hello,
This commit adds a preferred provider for u-boot's virtual package to fix an error with fitImage.
See the code of the [fitImage class](http://git.yoctoproject.org/cgit/cgit.cgi/poky/tree/meta/classes/kernel-fitimage.bbclass?h=morty#n26).
Fixes #100.
Best regards,
Mylène