### PR TITLE
u-boot-at91: add u-boot to PROVIDES

### DIFF
--- a/recipes-bsp/u-boot/u-boot-atmel.inc
+++ b/recipes-bsp/u-boot/u-boot-atmel.inc
@@ -1,7 +1,7 @@
 DESCRIPTION = "U-Boot - the Universal Boot Loader"
 HOMEPAGE = "http://www.denx.de/wiki/U-Boot/WebHome"
 SECTION = "bootloaders"
-PROVIDES = "virtual/bootloader"
+PROVIDES = "u-boot virtual/bootloader"
 
 inherit uboot-config deploy
 


### PR DESCRIPTION
Without this option, the following
error appears (when integrating Mender for instance) :

=> ERROR: Nothing PROVIDES "u-boot"

Signed-off-by: Pierre-Jean Texier <pierre-jean.texier@lafon.fr>