### PR TITLE
qtbase: stop modifying it for other MACHINEs

### DIFF
--- a/dynamic-layers/qt5-layer/recipes-qt/qt5/qtbase_%.bbappend
+++ b/dynamic-layers/qt5-layer/recipes-qt/qt5/qtbase_%.bbappend
@@ -1,8 +1,13 @@
-FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
-SRC_URI += "file://atmel-color-format-force.patch \
+FILESEXTRAPATHS_prepend_sama5 := "${THISDIR}/files:"
+FILESEXTRAPATHS_prepend_at91sam9 := "${THISDIR}/files:"
+
+ATMEL_PATCHES = "file://atmel-color-format-force.patch \
             file://0001-make-QGraphicsItem-update-virtual.patch \
             file://0004-Provide-access-to-linuxfb-dri-fd-through-platform.patch \
             file://0005-Support-DRM-KMS-planes-in-linuxfb-DRM-backend.patch "
+
+SRC_URI_append_at91sam9 = " ${ATMEL_PATCHES}"
+SRC_URI_append_sama5 = " ${ATMEL_PATCHES}"
 
 # No egl on SAM9 or SAMA5
 QT_CONFIG_FLAGS_append_at91sam9 = "${@bb.utils.contains('DISTRO_FEATURES', 'x11', \
@@ -10,11 +15,18 @@ QT_CONFIG_FLAGS_append_at91sam9 = "${@bb.utils.contains('DISTRO_FEATURES', 'x11'
 QT_CONFIG_FLAGS_append_sama5 = "${@bb.utils.contains('DISTRO_FEATURES', 'x11', \
                             ' -no-eglfs', ' -no-opengl -linuxfb -qpa linuxfb -no-eglfs', d)}"
 
-PACKAGECONFIG[kms] = "-kms,-no-kms,drm libdrm"
-PACKAGECONFIG += "kms"
+PACKAGECONFIG_append_at91sam9 = " kms"
+PACKAGECONFIG_append_sama5 = " kms"
 
-PACKAGECONFIG_append = " xkbcommon-evdev"
-PACKAGECONFIG_remove = " tests"
+# kms PACKAGECONFIG depends on virtual/egl, we don't want that
+# https://github.com/linux4sam/meta-atmel/commit/e943ecf879f43b7117e50c2ac4c0c0c8d6f97986
+DEPENDS_remove_at91sam9 = "virtual/egl"
+DEPENDS_remove_sama5 = "virtual/egl"
+
+PACKAGECONFIG_append_at91sam9 = " xkbcommon-evdev"
+PACKAGECONFIG_append_sama5 = " xkbcommon-evdev"
+PACKAGECONFIG_remove_at91sam9 = " tests"
+PACKAGECONFIG_remove_sama5 = " tests"
 
 # qtwebkit will fail later in the build if icu is not enabled. As Poky does not
 # enable it, do it here. This should be removed when the reverse dependency is


### PR DESCRIPTION
* use proper overrides and apply extra patches and PACKAGECONFIGs only
  for sama5 and at91sam9
* drop kms PACKAGECONFIG, almost the same is in qtbase with correct
  dependencies:
  PACKAGECONFIG[kms] = "-kms,-no-kms,drm virtual/egl"

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>