### PR TITLE
[thud] : cherry-pick (sama5.inc: Add wic option to not update fstab)

### DIFF
--- a/conf/machine/include/sama5.inc
+++ b/conf/machine/include/sama5.inc
@@ -13,3 +13,4 @@ PREFERRED_PROVIDER_jpeg ?= "jpeg"
 PREFERRED_PROVIDER_jpeg-native ?= "jpeg-native"
 
 SERIAL_CONSOLES ?= "115200;ttyS0"
+WIC_CREATE_EXTRA_ARGS ?= "--no-fstab-update"


### PR DESCRIPTION
This avoids mount warnings e.g. when it tries to mount
/dev/mmcblkp1 onto /boot and such a partition is non-existent
and boot falls into emergency shell.

=> Mounting all non-network filesystems...
mount: mounting /dev/mmcblkp1 on /boot failed: No such file or directory

Cannot continue due to errors above, starting emergency shell.

Signed-off-by: Khem Raj <raj.khem@gmail.com>
(cherry picked from commit dcd00e2883f6404bdc9c22b01c31a13c4f1495e0)