### PR TITLE
atmel-qt-demo-init: Update checksums for LICENSE

### DIFF
--- a/recipes-atmel/apps/atmel-qt-demo-init_1.1.bb
+++ b/recipes-atmel/apps/atmel-qt-demo-init_1.1.bb
@@ -6,7 +6,7 @@ PR = "r2"
 DEPENDS = "fbset"
 RDEPENDS_${PN} = "udev-rules-at91"
 
-LIC_FILES_CHKSUM = "file://${COREBASE}/LICENSE;md5=4d92cd373abda3937c2bc47fbc49d690 \
+LIC_FILES_CHKSUM = "file://${COREBASE}/LICENSE;md5=b97a012949927931feb7793eee5ed924 \
                     file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
 
 do_install() {


### PR DESCRIPTION
OE-Core has reworded the license file see
https://git.openembedded.org/openembedded-core/commit/?id=f8c9c511b5f1b7dbd45b77f345cb6c048ae6763e

Signed-off-by: Khem Raj <raj.khem@gmail.com>