### PR TITLE
bsp/u-boot: fix default environment generation

### DIFF
--- a/recipes-bsp/u-boot/u-boot-envs-atmel.inc
+++ b/recipes-bsp/u-boot/u-boot-envs-atmel.inc
@@ -1,16 +1,22 @@
 # U-Boot Environments for AT91 boards
 
-SRC_URI_append = " file://*.txt"
+SRC_URI_append = " file://envs/"
 
 ENV_SIZE = "0x4000"
 ENV_FILENAME = "uboot.env"
 ENV_FILEPATH = "${WORKDIR}/envs"
 
-do_deploy_append() {
+do_compile_append() {
     if [ -e "${ENV_FILEPATH}/${MACHINE}.txt" ]; then
-        echo "Compile u-boot environment for ${MACHINE} and deploy it."
+        echo "Compile U-Boot environment for ${MACHINE}"
         ${B}/tools/mkenvimage -s ${ENV_SIZE} ${ENV_FILEPATH}/${MACHINE}.txt -o ${ENV_FILENAME}
     else
         echo "No custom environment available for ${MACHINE}."
+    fi
+}
+
+do_deploy_append() {
+    if [ -e  ${B}/${ENV_FILENAME} ]; then
+        install -Dm 0644 ${B}/${ENV_FILENAME} ${DEPLOYDIR}
     fi
 }


### PR DESCRIPTION
This commit fixes :

| ERROR: _exec_cmd: ...
| output: install: cannot stat '<path>/tmp/deploy/images/sama5d27-som1-ek-sd/uboot.env': No such file or directory

Also fixes the deploy step. Now, the wic image contains the file uboot.env:

$ wic ls <path>/tmp/deploy/images/sama5d27-som1-ek-sd/<image>.rootfs.wic:1
Volume in drive : is boot
 Volume Serial Number is 0F36-08EB
Directory for ::/

AT91-S~1 DTB     44915 2019-05-13   7:03  at91-sama5d27_som1_ek.dtb
BOOT     BIN     19177 2019-05-13   7:03
SAMA5D~1 ITB   4089100 2019-05-13   7:03  sama5d27_som1_ek.itb
u-boot   bin    463975 2019-05-13   7:03
uboot    env     16384 2019-05-13   7:03
ZIMAGE         4023792 2019-05-13   7:03  zImage

Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>