### PR TITLE
Fix at91bootstrap

### DIFF
--- a/recipes-bsp/at91bootstrap/at91bootstrap_3.8.12.bb
+++ b/recipes-bsp/at91bootstrap/at91bootstrap_3.8.12.bb
@@ -4,11 +4,9 @@ LIC_FILES_CHKSUM = "file://main.c;endline=27;md5=a2a70db58191379e2550cbed95449fb
 
 COMPATIBLE_MACHINE = '(sama5d3xek|sama5d3-xplained|sama5d3-xplained-sd|at91sam9x5ek|at91sam9rlek|at91sam9m10g45ek|sama5d4ek|sama5d4-xplained|sama5d4-xplained-sd|sama5d2-xplained|sama5d2-xplained-sd|sama5d2-xplained-emmc|sama5d2-ptc-ek|sama5d2-ptc-ek-sd|sama5d27-som1-ek|sama5d27-som1-ek-sd)'
 
-SRC_URI = "git://github.com/linux4sam/at91bootstrap.git;protocol=https \
+SRC_URI = "https://github.com/linux4sam/at91bootstrap/archive/v3.8.12.tar.gz \
            file://0001-Add-an-option-to-enable-SAM-BA-download.patch \
 "
 
-PV = "3.8.12+git${SRCPV}"
-SRCREV = "28e15d07e9f24efb04b87bb0baa211a0c5640ef1"
-
-S = "${WORKDIR}/git"
+SRC_URI[md5sum] = "9cdcd5b427a7998315e9a0cad4488ffd"
+SRC_URI[sha256sum] = "871140177e2cab7eeed572556025f9fdc5e82b2bb18302445d13db0f95e21694"

--- a/recipes-bsp/at91bootstrap/at91bootstrap_git.bb
+++ b/recipes-bsp/at91bootstrap/at91bootstrap_git.bb
@@ -3,8 +3,8 @@ require at91bootstrap.inc
 DEFAULT_PREFERENCE = "-1"
 
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://github.com/linux4sam/at91bootstrap.git;protocol=git \
-          "
+SRC_URI = "${@bb.utils.contains('BB_NO_NETWORK', '1', '', 'git://github.com/linux4sam/at91bootstrap.git;protocol=git', d)}"
+
 S = "${WORKDIR}/git"
 
 PV = "3.8+git${SRCPV}"


### PR DESCRIPTION
As reported by Pierre-Jean, meta-atmel breaks BB_NO_NETWORK.

Instead, only break at91bootstrap_git at build time as it would not build anyway. Maybe the other solution would be to drop the recipe as it has DEFAULT_PREFERENCE = "-1" and probably doesn't see much testing.