### PR TITLE
at91bootstrap-sam-ba: fix S

### DIFF
--- a/recipes-bsp/at91bootstrap/at91bootstrap-sam-ba_3.8.12.bb
+++ b/recipes-bsp/at91bootstrap/at91bootstrap-sam-ba_3.8.12.bb
@@ -2,6 +2,8 @@ require at91bootstrap_${PV}.bb
 
 SRC_URI += "file://0002-Enable-image-download-via-sam-ba.patch"
 
+S = "${WORKDIR}/at91bootstrap-${PV}"
+
 AT91BOOTSTRAP_IMAGE .= "-sam-ba"
 AT91BOOTSTRAP_SYMLINK .= "-sam-ba"
 


### PR DESCRIPTION
Due to the fact this recipe (at91bootstrap-sam-ba) requires the
at91bootstrap_${PV} recipe, the code source location ($S) gets confused, and
bitbake doesn't know where to find the sources. Therefore it can't patch, do
the licensing, etc.

By explicitly setting the $S variable, bitbake is able to find the sources.

Signed-off-by: Trevor Woerner <twoerner@gmail.com>