### PR TITLE
at91bootstrap: remove stray patch from recipe

### DIFF
--- a/recipes-bsp/at91bootstrap/at91bootstrap_3.8.13.bb
+++ b/recipes-bsp/at91bootstrap/at91bootstrap_3.8.13.bb
@@ -5,7 +5,6 @@ LIC_FILES_CHKSUM = "file://main.c;endline=27;md5=a2a70db58191379e2550cbed95449fb
 COMPATIBLE_MACHINE = '(sama5d3xek|sama5d3-xplained|sama5d3-xplained-sd|at91sam9x5ek|at91sam9rlek|at91sam9m10g45ek|sama5d4ek|sama5d4-xplained|sama5d4-xplained-sd|sama5d2-xplained|sama5d2-xplained-sd|sama5d2-xplained-emmc|sama5d2-ptc-ek|sama5d2-ptc-ek-sd|sama5d27-som1-ek|sama5d27-som1-ek-sd|sama5d2-icp-sd)'
 
 SRC_URI = "git://github.com/linux4sam/at91bootstrap.git;protocol=https \
-           file://0001-Add-an-option-to-enable-SAM-BA-download.patch \
 "
 
 PV = "3.8.13+git${SRCPV}"


### PR DESCRIPTION
at91bootstrap is the in-house proprietary bootloader.
We should not apply patches to it via meta yocto layer.
all patches should go through at91bootstrap project and at91bootstrap
maintainers.
The patches here are for reference only, and should not be applied
in the recipes.
Patch owners should send patches through at91bootstrap patch channels.

Signed-off-by: Eugen Hristev <eugen.hristev@microchip.com>