### PR TITLE
Patch qtmultimedia in QT 5.12.4 to fix compile issue when -no-opengl …

### DIFF
--- a/dynamic-layers/qt5-layer/recipes-qt/qt5/qtmultimedia/0001-fix-qt5.12.4-compile-issue-when-no-opengl-in-QVideoSurfa.patch
+++ b/dynamic-layers/qt5-layer/recipes-qt/qt5/qtmultimedia/0001-fix-qt5.12.4-compile-issue-when-no-opengl-in-QVideoSurfa.patch
@@ -1,0 +1,39 @@
+From cc61850a28855ee7778b73e5ed70c23ac26dd823 Mon Sep 17 00:00:00 2001
+From: Nate Drude <nate.drude@emerson.com>
+Date: Thu, 25 Jul 2019 08:56:23 -0500
+Subject: [PATCH] A5-9: Fix compile issue when no opengl in
+ QVideoSurfacePainterFix qtmultimedia build issue with QT 5.12.4 when
+ -no-opengl is used
+
+See: https://gitweb.gentoo.org/proj/qt.git/tree/dev-qt/qtmultimedia/files/qtmultimedia-5.12.4-fix-no-opengl.patch?id=c0f69728fe2538b50a9daf12ea241a76c4b5d131
+---
+ src/multimediawidgets/qpaintervideosurface.cpp | 9 +++++----
+ 1 file changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/src/multimediawidgets/qpaintervideosurface.cpp b/src/multimediawidgets/qpaintervideosurface.cpp
+index 440d5c8..3e43814 100644
+--- a/src/multimediawidgets/qpaintervideosurface.cpp
++++ b/src/multimediawidgets/qpaintervideosurface.cpp
+@@ -57,10 +57,6 @@
+ #ifndef GL_RGB8
+ #define GL_RGB8 0x8051
+ #endif
+-#endif
+-
+-#include <QtDebug>
+-QT_BEGIN_NAMESPACE
+ 
+ static void makeCurrent(QGLContext *context)
+ {
+@@ -71,6 +67,11 @@ static void makeCurrent(QGLContext *context)
+         handle->makeCurrent(handle->surface());
+ }
+ 
++#endif
++
++#include <QtDebug>
++QT_BEGIN_NAMESPACE
++
+ QVideoSurfacePainter::~QVideoSurfacePainter()
+ {
+ }

--- a/dynamic-layers/qt5-layer/recipes-qt/qt5/qtmultimedia_%.bbappend
+++ b/dynamic-layers/qt5-layer/recipes-qt/qt5/qtmultimedia_%.bbappend
@@ -1,0 +1,4 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+#Patch for QT 5.12.4 only
+SRC_URI += "${@bb.utils.contains('SRCREV', 'd73b59093ec6fed8138460adcdf3ea0a45519a3c', 'file://0001-fix-qt5.12.4-compile-issue-when-no-opengl-in-QVideoSurfa.patch', '', d)}"


### PR DESCRIPTION
This patch fixes compile errors when building qtmultimedia 5.12.4 with -no-opengl for the SAMA5D27.