### PR TITLE
at91bootstrap: bump to tag v3.9.0-rc2

### DIFF
--- a/recipes-bsp/at91bootstrap/at91bootstrap_3.9.0.bb
+++ b/recipes-bsp/at91bootstrap/at91bootstrap_3.9.0.bb
@@ -8,6 +8,6 @@ SRC_URI = "git://github.com/linux4sam/at91bootstrap.git;protocol=https \
 "
 
 PV = "3.9.0+git${SRCPV}"
-SRCREV = "9a0bafe0fef0da7f4cac300da138959cff3b6bda"
+SRCREV = "98145e69e4cd3a21f023ee412f9b470d28aba508"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
This includes the following changes:

98145e6 Makefile: prepare 3.9.0-rc2
409fb89 lib: memcpy: fix memcpy and memset to standard return pointers
cae6f80 board: sama5d2: fix plla charge pump register
ce0d89d include: arch: pmc-v1: fix macros values
d15b9de driver: pmc: pll-clk: remove unnecessary #ifdef
bee0d23 driver: pmc: pll-clk: revert to using *ALT_MULA* macros

Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>