### PR TITLE
Rework recipes to fetch using git and https protocol

### DIFF
--- a/dynamic-layers/qt5-layer/recipes-qt/apps/homeautomation_1.10.bb
+++ b/dynamic-layers/qt5-layer/recipes-qt/apps/homeautomation_1.10.bb
@@ -9,12 +9,11 @@ PACKAGES = "${PN}-dbg ${PN}"
 DEPENDS = "qtbase qtwebkit libv4l"
 inherit qmake5
 
-SRC_URI = "https://github.com/linux4sam/home-automation/archive/v${PV}.tar.gz;downloadfilename=home-automation-${PV}.tar.gz"
+SRC_URI = "git://github.com/linux4sam/home-automation.git;protocol=https"
+PV = "1.10+git${SRCPV}"
+SRCREV = "fc7a4a910799d771ac27706088c7f4c294c580c3"
 
-SRC_URI[md5sum] = "4f2ea34a05e74557697eb9d3e49679fe"
-SRC_URI[sha256sum] = "ac7ea4ab4ee474c453d1339199fa71a8a3c20c007dfaac3fef68285384d994e0"
-
-S = "${WORKDIR}/home-automation-${PV}"
+S = "${WORKDIR}/git"
 
 inherit pkgconfig
 

--- a/dynamic-layers/qt5-layer/recipes-qt/apps/minehunt_1.7.bb
+++ b/dynamic-layers/qt5-layer/recipes-qt/apps/minehunt_1.7.bb
@@ -4,15 +4,14 @@ LIC_FILES_CHKSUM = "file://main.cpp;endline=40;md5=ade79b42cecba4adb92be7b0e83ba
 
 PACKAGES = "${PN}-dbg ${PN}"
 
-DEPENDS = "qtbase"
+DEPENDS = "qtbase qtdeclarative"
 inherit qmake5
 
-SRC_URI = "https://github.com/linux4sam/minehunt/archive/v${PV}.tar.gz;downloadfilename=${PN}-${PV}.tar.gz"
+SRC_URI = "git://github.com/linux4sam/minehunt.git;protocol=https"
+PV = "1.7+git${SRCPV}"
+SRCREV = "0bc4b8273dc828827d0e591053a84213c999434c"
 
-SRC_URI[md5sum] = "c7bff519050bdd1daddc8f3a8eb92f5d"
-SRC_URI[sha256sum] = "17d7f0141bfb038819ee5b0e3706422865dad146776bbb641633c7fc8c937954"
-
-S = "${WORKDIR}/${PN}-${PV}"
+S = "${WORKDIR}/git"
 
 inherit pkgconfig
 

--- a/dynamic-layers/qt5-layer/recipes-qt/apps/qmlbrowser_1.7.bb
+++ b/dynamic-layers/qt5-layer/recipes-qt/apps/qmlbrowser_1.7.bb
@@ -8,8 +8,6 @@ PR = "r1"
 
 inherit qmake5
 
-DEPENDS += "qtbase qtdeclarative qtwebkit"
-
 SRC_URI = "git://github.com/linux4sam/qml-browser.git;protocol=https"
 PV = "1.7+git${SRCPV}"
 SRCREV = "0626a3e087940bca6ced55ceee0df0074c0e9fee"

--- a/dynamic-layers/qt5-layer/recipes-qt/apps/qmlbrowser_1.7.bb
+++ b/dynamic-layers/qt5-layer/recipes-qt/apps/qmlbrowser_1.7.bb
@@ -8,12 +8,13 @@ PR = "r1"
 
 inherit qmake5
 
-SRC_URI = "https://github.com/linux4sam/qml-browser/archive/v${PV}.tar.gz;downloadfilename=qml-browser-${PV}.tar.gz"
+DEPENDS += "qtbase qtdeclarative qtwebkit"
 
-SRC_URI[md5sum] = "283afa2e34160373c4ae333c5f8b5c6d"
-SRC_URI[sha256sum] = "12e5896ec52428e1283adf2775e354684f7309c3f558e110732dca961912f814"
+SRC_URI = "git://github.com/linux4sam/qml-browser.git;protocol=https"
+PV = "1.7+git${SRCPV}"
+SRCREV = "0626a3e087940bca6ced55ceee0df0074c0e9fee"
 
-S = "${WORKDIR}/qml-browser-${PV}"
+S = "${WORKDIR}/git"
 
 inherit pkgconfig
 

--- a/dynamic-layers/qt5-layer/recipes-qt/apps/samegame_1.6.bb
+++ b/dynamic-layers/qt5-layer/recipes-qt/apps/samegame_1.6.bb
@@ -7,10 +7,9 @@ PACKAGES = "${PN}-dbg ${PN}"
 DEPENDS = "qtbase qtdeclarative"
 inherit qmake5
 
-SRC_URI = "https://github.com/linux4sam/samegame/archive/v${PV}.tar.gz;downloadfilename=${PN}-${PV}.tar.gz"
-
-SRC_URI[md5sum] = "39709b52871275bf575cad21ffaf134a"
-SRC_URI[sha256sum] = "1488fd156f2c69e6ef4b6d5c0ef3f16526a91769ca7bbbf433f4975c64ea8ba8"
+SRC_URI = "git://github.com/linux4sam/samegame.git;protocol=https"
+PV = "1.6+git${SRCPV}"
+SRCREV = "795cbd545a13ce49d1cde3887a5b7e2d91c46866"
 
 S = "${WORKDIR}/${PN}-${PV}"
 

--- a/dynamic-layers/qt5-layer/recipes-qt/apps/samegame_1.6.bb
+++ b/dynamic-layers/qt5-layer/recipes-qt/apps/samegame_1.6.bb
@@ -11,7 +11,7 @@ SRC_URI = "git://github.com/linux4sam/samegame.git;protocol=https"
 PV = "1.6+git${SRCPV}"
 SRCREV = "795cbd545a13ce49d1cde3887a5b7e2d91c46866"
 
-S = "${WORKDIR}/${PN}-${PV}"
+S = "${WORKDIR}/git"
 
 inherit pkgconfig
 

--- a/dynamic-layers/qt5-layer/recipes-qt/apps/smartrefrigerator_1.6.bb
+++ b/dynamic-layers/qt5-layer/recipes-qt/apps/smartrefrigerator_1.6.bb
@@ -9,10 +9,9 @@ PACKAGES = "${PN}-dbg ${PN}"
 DEPENDS = "qtbase qtwebkit libv4l"
 inherit qmake5
 
-SRC_URI = "https://github.com/linux4sam/smart-refrigerator/archive/v${PV}.tar.gz;downloadfilename=smart-refrigerator-${PV}.tar.gz"
-
-SRC_URI[md5sum] = "8ab327de0d10c725d593fbf53929f124"
-SRC_URI[sha256sum] = "413b95c9d31c2625e7184bc5833820780dfa64886c5dba73edb3cfe75959a4a4"
+SRC_URI = "git://github.com/linux4sam/smart-refrigerator.git;protocol=https"
+PV = "1.6+git${SRCPV}"
+SRCREV = "5c7bbb38ec639313d6b0e0d8e6919856eff8fc0a"
 
 S = "${WORKDIR}/smart-refrigerator-${PV}"
 

--- a/dynamic-layers/qt5-layer/recipes-qt/apps/smartrefrigerator_1.6.bb
+++ b/dynamic-layers/qt5-layer/recipes-qt/apps/smartrefrigerator_1.6.bb
@@ -13,7 +13,7 @@ SRC_URI = "git://github.com/linux4sam/smart-refrigerator.git;protocol=https"
 PV = "1.6+git${SRCPV}"
 SRCREV = "5c7bbb38ec639313d6b0e0d8e6919856eff8fc0a"
 
-S = "${WORKDIR}/smart-refrigerator-${PV}"
+S = "${WORKDIR}/git"
 
 inherit pkgconfig
 

--- a/recipes-bsp/at91bootstrap/at91bootstrap_3.8.12.bb
+++ b/recipes-bsp/at91bootstrap/at91bootstrap_3.8.12.bb
@@ -4,9 +4,8 @@ LIC_FILES_CHKSUM = "file://main.c;endline=27;md5=a2a70db58191379e2550cbed95449fb
 
 COMPATIBLE_MACHINE = '(sama5d3xek|sama5d3-xplained|sama5d3-xplained-sd|at91sam9x5ek|at91sam9rlek|at91sam9m10g45ek|sama5d4ek|sama5d4-xplained|sama5d4-xplained-sd|sama5d2-xplained|sama5d2-xplained-sd|sama5d2-xplained-emmc|sama5d2-ptc-ek|sama5d2-ptc-ek-sd|sama5d27-som1-ek|sama5d27-som1-ek-sd)'
 
-SRC_URI = "https://github.com/linux4sam/at91bootstrap/archive/v3.8.12.tar.gz \
+SRC_URI = "https://github.com/linux4sam/at91bootstrap.git;protocol=https \
            file://0001-Add-an-option-to-enable-SAM-BA-download.patch \
 "
-
-SRC_URI[md5sum] = "9cdcd5b427a7998315e9a0cad4488ffd"
-SRC_URI[sha256sum] = "871140177e2cab7eeed572556025f9fdc5e82b2bb18302445d13db0f95e21694"
+PV = "3.8.12+git${SRCPV}"
+SRCREV = "28e15d07e9f24efb04b87bb0baa211a0c5640ef1"


### PR DESCRIPTION
Pointing archives can lead to checksums issues due to github
regeneration.The protocol https is preconised to avoid proxy issues.

See https://github.com/linux4sam/meta-atmel/pull/99 for details.

Signed-off-by: Kamel Bouhara <kamel.bouhara@bootlin.com>