### PR TITLE
layer.conf: Whitelist fbset->atmel-qt-demo-init dependency

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -25,5 +25,5 @@ BBFILES_DYNAMIC += " \
     \
 "
 
-LAYERSERIES_COMPAT_atmel = "thud warrior"
+LAYERSERIES_COMPAT_atmel = "thud warrior zeus"
 VIRTUAL-RUNTIME_alsa-state = ""

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,6 +10,12 @@ BBFILE_PRIORITY_atmel = "10"
 
 LICENSE_PATH += "${LAYERDIR}/licenses"
 
+SIGGEN_EXCLUDE_SAFE_RECIPE_DEPS += " \
+  fbset-modes->atmel-qt-demo-init \
+  fbset->atmel-qt-demo-init \
+  udev-rules-at91->atmel-qt-demo-init \
+"
+
 BBFILES_DYNAMIC += " \
     qt4-layer:${LAYERDIR}/dynamic-layers/qt4-layer/*/*/*.bb \
     qt4-layer:${LAYERDIR}/dynamic-layers/qt4-layer/*/*/*.bbappend \

--- a/recipes-atmel/apps/atmel-qt-demo-init_1.1.bb
+++ b/recipes-atmel/apps/atmel-qt-demo-init_1.1.bb
@@ -3,8 +3,7 @@ LICENSE = "MIT"
 SRC_URI = "file://atmel-qt-demo-init-v${PV}"
 PR = "r2"
 
-DEPENDS = "fbset"
-RDEPENDS_${PN} = "udev-rules-at91"
+RDEPENDS_${PN} = "udev-rules-at91 fbset"
 
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
 


### PR DESCRIPTION
Turn dep in fbset into rdep, its only needed during runtime in atmel-qt-demo-init

fbset has machine specific configuration but the ABI is safe as far as
atmel-qt-demo-init is concerned, this ensures that atmel-qt-demo-init is
not recompiling for no reason when machine is changed e.g. form qemuarm
to qemuarm64

Fixes
atmel-qt-demo-init-1.1: Package version for package atmel-qt-demo-init-src went backwards which would break package feeds from (0:1.1-r2.17 to 0:1.1-r2.16) [version-going-backwards]
atmel-qt-demo-init-1.1: Package version for package atmel-qt-demo-init-dbg went backwards which would break package feeds from (0:1.1-r2.17 to 0:1.1-r2.16) [version-going-backwards]
atmel-qt-demo-init-1.1: Package version for package atmel-qt-demo-init-staticdev went backwards which would break package feeds from (0:1.1-r2.17 to 0:1.1-r2.16) [version-going-backwards]

Signed-off-by: Khem Raj <raj.khem@gmail.com>