### PR TITLE
at91bootstrap: bump to tag v3.9.0-rc4

### DIFF
--- a/recipes-bsp/at91bootstrap/at91bootstrap_3.9.0.bb
+++ b/recipes-bsp/at91bootstrap/at91bootstrap_3.9.0.bb
@@ -8,6 +8,6 @@ SRC_URI = "git://github.com/linux4sam/at91bootstrap.git;protocol=https \
 "
 
 PV = "3.9.0+git${SRCPV}"
-SRCREV = "98145e69e4cd3a21f023ee412f9b470d28aba508"
+SRCREV = "13ef0f786a3f28b0932fd3fe10e52930f270892d"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
This includes the following changes:

13ef0f7 Makefile: prepare 3.9.0-rc4
0d61b6d board: sama5d27_wlsom1_ek: add config for BSR
83e11c5 driver: ddramc: add bsr support for lpddr2 memories with sama5d2
a5cbe08 board: sam9x60ek: wilc power sequence
817a7d8 sama5d27_som1_ek: fix over-consumption erratum check
016e638 board: sama5d27_wlsom1_ek: fix QSPI mode
7a2d6ba board: sam9x60_sdr_sip_eb: fix MPDDR bit selected by error

Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>