### PR TITLE
at91bootstrap: bump to tag v3.9.0-rc5

### DIFF
--- a/recipes-bsp/at91bootstrap/at91bootstrap_3.9.0.bb
+++ b/recipes-bsp/at91bootstrap/at91bootstrap_3.9.0.bb
@@ -8,6 +8,6 @@ SRC_URI = "git://github.com/linux4sam/at91bootstrap.git;protocol=https \
 "
 
 PV = "3.9.0+git${SRCPV}"
-SRCREV = "13ef0f786a3f28b0932fd3fe10e52930f270892d"
+SRCREV = "7b42a8e27aa203ea59a9427bf351753bda0a955c"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
This includes the following changes:

7b42a8e Makefile: prepare 3.9.0-rc5
69e8f73 sam9x60: adapt PMC_PLL_ACR to datasheet

Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>