### PR TITLE
dt-overlay-at91: do not install the FIT image source file on /boot

### DIFF
--- a/recipes-bsp/dt-overlay-at91/dt-overlay-at91_git.bb
+++ b/recipes-bsp/dt-overlay-at91/dt-overlay-at91_git.bb
@@ -62,7 +62,6 @@ do_install () {
     if [ -e ${AT91BOOTSTRAP_MACHINE}.itb ]; then
         install -d ${D}/boot
         install ${AT91BOOTSTRAP_MACHINE}.itb ${D}/boot/
-        install ${AT91BOOTSTRAP_MACHINE}.its ${D}/boot/
     fi;
 }
 


### PR DESCRIPTION
Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>