### PR TITLE
mchp-wireless-firmware: Use nonarch_base_libdir instead of hardcoding…

### DIFF
--- a/recipes-kernel/linux/mchp-wireless-firmware_15.2.bb
+++ b/recipes-kernel/linux/mchp-wireless-firmware_15.2.bb
@@ -11,18 +11,18 @@ S = "${WORKDIR}/git"
 inherit allarch
 
 do_install() {
-	install -d ${D}/lib/firmware/mchp/
-	cp -r ${S}/* ${D}/lib/firmware/mchp/
+	install -d ${D}${nonarch_base_libdir}/firmware/mchp/
+	cp -r ${S}/* ${D}${nonarch_base_libdir}/firmware/mchp/
 
 	# remove unneeded file
-	rm -f ${D}/lib/firmware/mchp/README.md
-	rm -rf ${D}/lib/firmware/mchp/LICENCE.wilc_fw
-	chmod -x ${D}/lib/firmware/mchp/*
+	rm -f ${D}${nonarch_base_libdir}/firmware/mchp/README.md
+	rm -rf ${D}${nonarch_base_libdir}/firmware/mchp/LICENCE.wilc_fw
+	chmod -x ${D}${nonarch_base_libdir}/firmware/mchp/*
 }
 
 
 FILES_${PN} += " \
-	${base_libdir}/firmware/mchp/wilc*.bin \
+	${nonarch_base_libdir}/firmware/mchp/wilc*.bin \
 	"
 
 # TODO: use ALTERNATIVE like in "linux-firmware" package


### PR DESCRIPTION
… firmware path prefix

This helps the build with multilib
Fixes
ERROR: mchp-wireless-firmware-15.2-r0 do_package: QA Issue: mchp-wireless-firmware: Files/directories were installed but not shipped in any package:
  /lib
  /lib/firmware
  /lib/firmware/mchp
  /lib/firmware/mchp/wilc3000_ble_firmware.bin
  /lib/firmware/mchp/wilc3000_wifi_firmware.bin
  /lib/firmware/mchp/wilc1000_wifi_firmware.bin
  /lib/firmware/mchp/wilc3000_ble_firmware_no_rtc.bin

Signed-off-by: Khem Raj <raj.khem@gmail.com>