### PR TITLE
Fix override of TOOLCHAIN_HOST_TASK which breaks populate_sdk

### DIFF
--- a/dynamic-layers/qt5-layer/recipes-qt/images/atmel-qt5-demo-image.bb
+++ b/dynamic-layers/qt5-layer/recipes-qt/images/atmel-qt5-demo-image.bb
@@ -135,4 +135,4 @@ IMAGE_INSTALL_append_sama5d2-ptc-ek-sd = " ptc-examples"
 inherit core-image populate_sdk_qt5
 
 #TOOLCHAIN_HOST_TASK += "nativesdk-sam-ba"
-TOOLCHAIN_HOST_TASK += "nativesdk-swig"
+TOOLCHAIN_HOST_TASK_append += " nativesdk-swig"


### PR DESCRIPTION
+= will immediately initialize TOOLCHAIN_HOST_TASK during parsing, and following ?= will not apply

_append waits until parsing is complete

Signed-off-by: Nate Drude <nate.drude@emerson.com>