### PR TITLE
egt-benchmark: Do not use c++ flags in CPPFLAGS

### DIFF
--- a/recipes-egt/apps/egt-benchmark/0001-configure-Do-not-add-C-compiler-flags-to-CPPFLAGS.patch
+++ b/recipes-egt/apps/egt-benchmark/0001-configure-Do-not-add-C-compiler-flags-to-CPPFLAGS.patch
@@ -1,0 +1,30 @@
+From dc1a6e863f096c89e80cfb536fb7a65072e06efc Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Wed, 6 May 2020 22:38:16 -0700
+Subject: [PATCH] configure: Do not add C++ compiler flags to CPPFLAGS
+
+CPPFLAGS is for c pre-processor and thusly added to CFLAGS as as well as
+CXXFLAGS, -std=c++14 is only valid for C++ compiler, therefore do not
+add it to CPPFLAGS
+
+Upstream-Status: Submitted [https://github.com/linux4sam/egt-benchmark/pull/1]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ configure.ac | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 4534ebd..21ac343 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -17,7 +17,6 @@ LT_PREREQ([2.2])
+ LT_INIT([win32-dll])
+ 
+ CXXFLAGS="$CXXFLAGS -std=c++14 -pedantic -g"
+-CPPFLAGS="$CPPFLAGS -std=c++14"
+ CFLAGS="$CFLAGS -g"
+ 
+ AX_PTHREAD([LIBS="$PTHREAD_LIBS $LIBS"
+-- 
+2.26.2
+

--- a/recipes-egt/apps/egt-benchmark_1.0.bb
+++ b/recipes-egt/apps/egt-benchmark_1.0.bb
@@ -4,21 +4,20 @@ LIC_FILES_CHKSUM = "file://COPYING;endline=202;md5=3b83ef96387f14655fc854ddc3c6b
 
 DEPENDS = "libegt"
 
-SRC_URI = "git://github.com/linux4sam/egt-benchmark.git;protocol=https"
+SRC_URI = "git://github.com/linux4sam/egt-benchmark.git;protocol=https \
+           file://0001-configure-Do-not-add-C-compiler-flags-to-CPPFLAGS.patch \
+          "
 
 SRCREV = "e20643eb2c6165e34dc52edbba488616a3aaae22"
 
 S = "${WORKDIR}/git"
 
-B = "${S}"
-
-inherit pkgconfig autotools
+inherit pkgconfig autotools-brokensep
 
 EXTRA_OECONF += "--program-prefix='egt_'"
 
 do_configure_prepend() {
-	( cd ${S};
-	${S}/autogen.sh; cd -)
+	( cd ${S} && ${S}/autogen.sh ) 
 }
 
 FILES_${PN} += " \


### PR DESCRIPTION
This ensures that configure tests using g++ do not fail

Fixes errors like

checking for pthread-config... no
configure: error: Can not find pthreads.  This is required.

Signed-off-by: Khem Raj <raj.khem@gmail.com>