### PR TITLE
at91bootstrap: do not use specific branch

### DIFF
--- a/recipes-bsp/at91bootstrap/at91bootstrap_3.9.3.bb
+++ b/recipes-bsp/at91bootstrap/at91bootstrap_3.9.3.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://main.c;endline=27;md5=a2a70db58191379e2550cbed95449fb
 
 COMPATIBLE_MACHINE = '(sama5d3xek|sama5d3-xplained|sama5d3-xplained-sd|at91sam9x5ek|at91sam9rlek|at91sam9m10g45ek|sama5d4ek|sama5d4-xplained|sama5d4-xplained-sd|sama5d2-xplained|sama5d2-xplained-sd|sama5d2-xplained-emmc|sama5d2-ptc-ek|sama5d2-ptc-ek-sd|sama5d27-som1-ek|sama5d27-som1-ek-sd|sama5d2-icp-sd|sam9x60ek|sam9x60ek-sd|sama5d27-wlsom1-ek-sd)'
 
-SRC_URI = "git://github.com/linux4sam/at91bootstrap.git;protocol=https;branch=at91bootstrap-3.x-python3"
+SRC_URI = "git://github.com/linux4sam/at91bootstrap.git;protocol=https"
 
 PV = "3.9.3+git${SRCPV}"
 SRCREV = "d96833a4b6680b237708eb4dc9f10708b9e709d8"


### PR DESCRIPTION
Branch "at91bootstrap-3.x-python3" does not exists anymore since
master includes python3 support, so use master instead.

Fixes:
 - http://51.75.135.20:8080/job/sama5d27-som1-ek-sd/75/console

Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>