### PR TITLE
cryptoauthlib: Changed eudev requirement to default value

### DIFF
--- a/recipes-security/cryptoauthlib/cryptoauthlib_git.bb
+++ b/recipes-security/cryptoauthlib/cryptoauthlib_git.bb
@@ -8,7 +8,7 @@ SRCREV = "2df0eb145c7241263d07577394dd12f8b1e783f0"
 
 S = "${WORKDIR}/git"
 
-DEPENDS = "eudev"
+DEPENDS ?= "eudev"
 RDEPENDS_${PN} = "libp11 (>= 0.4.10) gnutls-bin"
 RRECOMMENDS_${PN} = "p11-kit"
 


### PR DESCRIPTION
Currently the cryptoauthlib recipe sets eudev as a requirement with
basic variable setting.  As pointed out in issue #172 this breaks
cryptoauthlib's compatability if systemd is included with your build.
This is because eudev is not compatible with systemd.

As pointed out in issue #172, this can be resolved by changing the
requirement to udev.  Setting udev as a default requirement (?=)
allows a developer downstream to create a bbappends file that sets
REQUIREMENTS to udev with basic variable setting (=).

Signed-off-by: Colin McAllister <colinmca242@gmail.com>