### PR TITLE
added udev & CRYPTOAUTHLIB_NOUSB = True

### DIFF
--- a/recipes-support/python-cryptoauthlib/python3-cryptoauthlib_20200208.bb
+++ b/recipes-support/python-cryptoauthlib/python3-cryptoauthlib_20200208.bb
@@ -14,6 +14,6 @@ inherit pypi setuptools3
 
 RDEPENDS_${PN} += "python3-core python3-cryptography python3-ctypes python3-datetime python3-netclient"
 
-DEPENDS += "cmake-native udev"
+DEPENDS += "cmake-native ${@bb.utils.contains('DISTRO_FEATURES','systemd','udev','eudev',d)}"
 
 export CRYPTOAUTHLIB_NOUSB = "True"

--- a/recipes-support/python-cryptoauthlib/python3-cryptoauthlib_20200208.bb
+++ b/recipes-support/python-cryptoauthlib/python3-cryptoauthlib_20200208.bb
@@ -14,6 +14,6 @@ inherit pypi setuptools3
 
 RDEPENDS_${PN} += "python3-core python3-cryptography python3-ctypes python3-datetime python3-netclient"
 
-DEPENDS += "cmake-native ${@bb.utils.contains('DISTRO_FEATURES','systemd','udev','eudev',d)}"
+DEPENDS += "cmake-native udev"
 
 export CRYPTOAUTHLIB_NOUSB = "True"

--- a/recipes-support/python-cryptoauthlib/python3-cryptoauthlib_20200208.bb
+++ b/recipes-support/python-cryptoauthlib/python3-cryptoauthlib_20200208.bb
@@ -14,4 +14,6 @@ inherit pypi setuptools3
 
 RDEPENDS_${PN} += "python3-core python3-cryptography python3-ctypes python3-datetime python3-netclient"
 
-DEPENDS += "cmake-native"
+DEPENDS += "cmake-native udev"
+
+export CRYPTOAUTHLIB_NOUSB = "True"


### PR DESCRIPTION
Added udev and also 'CRYPTOAUTHLIB_NOUSB = True' If a USB kit is not being used then environment variable CRYPTOAUTHLIB_NOUSB  needs to be set for the python build. 