### PR TITLE
cryptoauthlib: Use -fcommon to compile it

### DIFF
--- a/recipes-security/cryptoauthlib/cryptoauthlib_git.bb
+++ b/recipes-security/cryptoauthlib/cryptoauthlib_git.bb
@@ -16,6 +16,8 @@ inherit cmake
 
 EXTRA_OECMAKE = ""
 
+CFLAGS += "-fcommon"
+
 do_install_append_sama5d2() {
     install -Dm 644 ${WORKDIR}/cryptoauthlib.module ${D}${datadir}/p11-kit/modules/cryptoauthlib.module
     cp -p ${D}${localstatedir}/lib/cryptoauthlib/slot.conf.tmpl ${D}${localstatedir}/lib/cryptoauthlib/0.conf


### PR DESCRIPTION
gcc10 has changed the defaults to use -fno-common and this library needs
some work to get it going with -fno-common, until thats fixed lets keep
using good old -fcommon

Fixes a lot of multiple definition of XXX errors

Signed-off-by: Khem Raj <raj.khem@gmail.com>