### PR TITLE
noto-fonts: Use installed file permissions

### DIFF
--- a/recipes-egt/apps/noto-fonts.bb
+++ b/recipes-egt/apps/noto-fonts.bb
@@ -9,17 +9,21 @@ SRC_URI = "https://noto-website-2.storage.googleapis.com/pkgs/Noto-unhinted.zip"
 SRC_URI[md5sum] = "d26b29b10c3c8d05df4ade8286963722"
 SRC_URI[sha256sum] = "7d0e099c208d11d7bf64091ea7f62f85bc07dedfaf2c01de53985a5b981025e3"
 
-S = "${WORKDIR}/"
+S = "${WORKDIR}"
+
+inherit allarch fontcache
 
 FILES_${PN} += " \
-    /usr/share/fonts/noto/* \
+    ${datadir}/fonts/noto/* \
 "
+
 do_install() {
-        install -d ${D}/usr/share/fonts/noto
-        cp -Rf ${S}/NotoSans-Regular.ttf ${D}/usr/share/fonts/noto
-        cp -Rf ${S}/NotoSansCJKsc-Regular.otf ${D}/usr/share/fonts/noto
-        cp -Rf ${S}/NotoColorEmoji.ttf ${D}/usr/share/fonts/noto
+        install -Dm 0644 ${S}/NotoSans-Regular.ttf ${D}${datadir}/fonts/noto/NotoSans-Regular.ttf
+        install -Dm 0644 ${S}/NotoSansCJKsc-Regular.otf ${D}${datadir}/fonts/noto/NotoSansCJKsc-Regular.otf
+        install -Dm 0644 ${S}/NotoColorEmoji.ttf ${D}${datadir}/fonts/noto/NotoColorEmoji.ttf
 }
+
+do_compile[noexec] = "1"
 
 ALLOW_EMPTY_${PN} = "1"
 INHIBIT_DEFAULT_DEPS = "1"


### PR DESCRIPTION
cp does not maintain proper user name and group, therefore use install
utility to install files.

Use datadir instead of hardcoding /usr/share

Mark do_compile as noexec since we only need do_install onwards

Signed-off-by: Khem Raj <raj.khem@gmail.com>