### PR TITLE
layer.conf: Add noto-fonts dep on fontconfig to exclude from signatures

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -12,6 +12,7 @@ LICENSE_PATH += "${LAYERDIR}/licenses"
 
 SIGGEN_EXCLUDE_SAFE_RECIPE_DEPS += " \
   mchp-egt-demo-init->udev-rules-at91 \
+  noto-fonts->fontconfig \
 "
 
 BBFILES_DYNAMIC += " \


### PR DESCRIPTION
This ensures that this package can stay allarch and does not recompile
when machine is changed

Fixes
 === Comparing signatures for task do_package_write_ipk.sigdata between qemux86copy and qemuarm ===
ERROR: noto-fonts different signature for task do_package_write_ipk.sigdata between qemux86copy and qemuarm

Signed-off-by: Khem Raj <raj.khem@gmail.com>