### PR TITLE
dt-overlay-at91: Implement logic for using kernel+initramfs when sele…

### DIFF
--- a/recipes-bsp/dt-overlay-at91/dt-overlay-at91_git.bb
+++ b/recipes-bsp/dt-overlay-at91/dt-overlay-at91_git.bb
@@ -24,6 +24,12 @@ AT91BOOTSTRAP_MACHINE ??= "${MACHINE}"
 do_compile[depends] += "virtual/kernel:do_deploy virtual/kernel:do_shared_workdir"
 do_compile[nostamp] = "1"
 
+do_configure_append() {
+    if ${@bb.utils.contains('INITRAMFS_IMAGE_BUNDLE','1','true','false',d)}; then
+        sed -i -e "s#\"./zImage\"#\"./zImage-initramfs-${MACHINE}.bin\"#" ${S}/${AT91BOOTSTRAP_MACHINE}.its
+    fi
+}
+
 do_compile () {
     # Check to properly identify the board
     if [ -z "${AT91BOOTSTRAP_MACHINE}" ]; then


### PR DESCRIPTION
…cted

Currently, zImage is hardcoded into .its files, this is limiting when
user is in need of using a kernel bundled with initramfs image, this is
nicely reflected with INITRAMFS_IMAGE_BUNDLE from config metadata and
the image name is also consistent which is
KERNEL_IMAGETYPE-initramfs-MACHINE.bin, therefore emit this into the
relevant .its file when initramfs is being used.

This would not come in picuture when INITRAMFS_IMAGE_BUNDLE is not set
hence the default behavior remains as it is.

Signed-off-by: Khem Raj <raj.khem@gmail.com>