### PR TITLE
libegt: Skip it for Big-endian targets

### DIFF
--- a/recipes-graphics/libegt/libegt_1.1.bb
+++ b/recipes-graphics/libegt/libegt_1.1.bb
@@ -71,3 +71,9 @@ do_install_append() {
     rm -f ${D}/usr/share/egt/examples/audioplayer/*.mp3
     rm -f ${D}/usr/share/egt/examples/drummachine/*.wav
 }
+
+python __anonymous () {
+    endianness = d.getVar('SITEINFO_ENDIANNESS')
+    if endianness == 'be':
+        raise bb.parse.SkipRecipe('Requires little-endian target.')
+}


### PR DESCRIPTION
Fixes

| ./detail/erawimage.h:39:1: error: static_assert failed due to requirement 'end
ian::native == endian::little' "eraw implementation only works on little"
| static_assert(endian::native == endian::little,
| ^             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
| 1 error generated.
| make[3]: *** [Makefile:2532: detail/libegt_la-eraw.lo] Error 1

Signed-off-by: Khem Raj <raj.khem@gmail.com>