### PR TITLE
recipes/images: Cordon off libegt dependent packages

### DIFF
--- a/recipes-atmel/images/microchip-graphics-image.bb
+++ b/recipes-atmel/images/microchip-graphics-image.bb
@@ -83,12 +83,7 @@ IMAGE_INSTALL += "\
 	phytool \
 	tcpdump \
 	kea \
-	libegt \
-	egt-launcher \
-	egt-samples \
-	egt-media \
-	egt-thermostat \
-	egt-benchmark \
+        ${@oe.utils.conditional('SITEINFO_ENDIANNESS', 'le', 'libegt egt-launcher egt-samples egt-media egt-thermostat egt-benchmark', '', d)} \
 	noto-fonts \
 "
 

--- a/recipes-egt/apps/egt-benchmark_1.0.bb
+++ b/recipes-egt/apps/egt-benchmark_1.0.bb
@@ -15,9 +15,15 @@ inherit pkgconfig autotools-brokensep
 EXTRA_OECONF += "--program-prefix='egt_'"
 
 do_configure_prepend() {
-	( cd ${S} && ${S}/autogen.sh ) 
+	( cd ${S} && ${S}/autogen.sh )
 }
 
 FILES_${PN} += " \
     ${datadir}/egt/* \
 "
+
+python __anonymous () {
+    endianness = d.getVar('SITEINFO_ENDIANNESS')
+    if endianness == 'be':
+        raise bb.parse.SkipRecipe('Requires little-endian target.')
+}

--- a/recipes-egt/apps/egt-launcher_1.1.bb
+++ b/recipes-egt/apps/egt-launcher_1.1.bb
@@ -32,3 +32,8 @@ B = "${S}"
 FILES_${PN} += " \
     /usr/share/egt/* \
 "
+python __anonymous () {
+    endianness = d.getVar('SITEINFO_ENDIANNESS')
+    if endianness == 'be':
+        raise bb.parse.SkipRecipe('Requires little-endian target.')
+}

--- a/recipes-egt/apps/egt-media_1.3.bb
+++ b/recipes-egt/apps/egt-media_1.3.bb
@@ -32,3 +32,10 @@ do_install() {
 
 ALLOW_EMPTY_${PN} = "1"
 INHIBIT_DEFAULT_DEPS = "1"
+
+python __anonymous () {
+    endianness = d.getVar('SITEINFO_ENDIANNESS')
+    if endianness == 'be':
+        raise bb.parse.SkipRecipe('Requires little-endian target.')
+}
+

--- a/recipes-egt/apps/egt-samples_1.1.bb
+++ b/recipes-egt/apps/egt-samples_1.1.bb
@@ -30,3 +30,9 @@ FILES_${PN} += " \
 B = "${S}"
 
 EXTRA_OECONF = "--program-prefix='egt_'"
+
+python __anonymous () {
+    endianness = d.getVar('SITEINFO_ENDIANNESS')
+    if endianness == 'be':
+        raise bb.parse.SkipRecipe('Requires little-endian target.')
+}

--- a/recipes-egt/apps/egt-thermostat_1.1.bb
+++ b/recipes-egt/apps/egt-thermostat_1.1.bb
@@ -33,3 +33,9 @@ do_install_append() {
 FILES_${PN} += " \
     ${datadir}/egt/* \
 "
+
+python __anonymous () {
+    endianness = d.getVar('SITEINFO_ENDIANNESS')
+    if endianness == 'be':
+        raise bb.parse.SkipRecipe('Requires little-endian target.')
+}


### PR DESCRIPTION
Since libegt will only work on Little-endian targets, until its fixed
these recipes should also be built form LE only targets

Signed-off-by: Khem Raj <raj.khem@gmail.com>