### PR TITLE
sam-ba: upgrade to 3.3.1

### DIFF
--- a/recipes-devtools/sam-ba/sam-ba_3.3.1.bb
+++ b/recipes-devtools/sam-ba/sam-ba_3.3.1.bb
@@ -5,8 +5,8 @@ LICENSE = "GPL-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 SRC_URI = "https://github.com/atmelcorp/${BPN}/releases/download/v${PV}/${BPN}_${PV}-linux_x86_64.tar.gz"
-SRC_URI[md5sum] = "11746fcc1f97e054fa6a8c9c57c12a20"
-SRC_URI[sha256sum] = "3ecd53dab9a60debe5a861e272e095da008300c860ce7494102ad987eea7c8e9"
+SRC_URI[md5sum] = "54f9c25b18a2a1afe2735b5da38e7580"
+SRC_URI[sha256sum] = "dc32c49688bbfab5aa687042caae5f611fe3d9e722098a561f8f5d2fbc57249d"
 
 inherit deploy
 


### PR DESCRIPTION
Upgrades current sam-ba flashing tool from 3.2.3 to 3.3.1. The newer (well Dec 2019) version, among other fixes, supports the sam9x60 device (and sam9x60-ek board) which we already have in meta-atmel as a machine (see [sam9x60ek.conf](https://github.com/linux4sam/meta-atmel/blob/dunfell/conf/machine/sam9x60ek.conf)) but we otherwise not have a sam-ba which actually supports its flashing.


Signed-off-by: Federico Pellegrin fede@evolware.org