### PR TITLE
u-boot: fix ubi partition for default environment for sam9x60ek board

### DIFF
--- a/recipes-bsp/u-boot/files/envs/sam9x60ek.txt
+++ b/recipes-bsp/u-boot/files/envs/sam9x60ek.txt
@@ -14,7 +14,7 @@ pda7000test=test -n $display && test $display = 7000 && setenv display_var 'pda7
 at91_prepare_overlays_config=test -n $display_var && setenv at91_overlays_config '#'${display_var}
 bootcmd=run at91_set_display; run at91_pda_detect; run at91_prepare_video_bootargs; run at91_prepare_bootargs; run at91_prepare_overlays_config; run bootcmd_boot;
 pda5000test=test -n $display && test $display = 5000 && setenv display_var 'pda5' && setenv video_mode ${video_mode_pda5}
-bootargs=console=ttyS0,115200 mtdparts=atmel_nand:256k(bootstrap)ro,768k(uboot)ro,256k(env_redundant),256k(env),6656k(itb)ro,-(rootfs) rootfstype=ubifs ubi.mtd=5 root=ubi0:rootfs rw atmel.pm_modes=standby,ulp0
+bootargs=console=ttyS0,115200 mtdparts=atmel_nand:256k(bootstrap)ro,768k(uboot)ro,256k(env_redundant),256k(env),6656k(itb)ro,-(rootfs) rootfstype=ubifs ubi.mtd=11 root=ubi0:rootfs rw atmel.pm_modes=standby,ulp0
 bootcmd_boot=nand read 0x24000000 0x00180000 0x680000; bootm 0x24000000#kernel_dtb${at91_overlays_config}
 bootdelay=1
 ethact=gmac0


### PR DESCRIPTION
For the sam9x60ek board in NAND configuration (not SD) the current value `ubi.mtd=5` seem to be wrong, being the correct `ubi.mtd=11` for the current kernel+board default configuration with flashing on NAND.

This can be seen in detail from the following:
```
Linux version 5.4.41-linux4sam-2020.04 (oe-user@oe-host) (gcc version 9.3.0 (GCC)) #1 Mon May 25 16:58:23 UTC 2020
CPU: ARM926EJ-S [41069265] revision 5 (ARMv5TEJ), cr=0005317f
CPU: VIVT data cache, VIVT instruction cache
OF: fdt: Machine model: Microchip SAM9X60-EK
...
spi-nor spi0.0: sst26vf064b (8192 Kbytes)
6 fixed-partitions partitions found on MTD device spi0
Creating 6 MTD partitions on "spi0":
0x000000000000-0x000000040000 : "qspi: at91bootstrap"
0x000000040000-0x000000100000 : "qspi: bootloader"
0x000000100000-0x000000140000 : "qspi: bootloader env redundant"
0x000000140000-0x000000180000 : "qspi: bootloader env"
0x000000180000-0x000000200000 : "qspi: device tree"
0x000000200000-0x000000800000 : "qspi: kernel"
...
6 cmdlinepart partitions found on MTD device atmel_nand
Creating 6 MTD partitions on "atmel_nand":
0x000000000000-0x000000040000 : "bootstrap"
0x000000040000-0x000000100000 : "uboot"
0x000000100000-0x000000140000 : "env_redundant"
0x000000140000-0x000000180000 : "env"
0x000000180000-0x000000800000 : "itb"
0x000000800000-0x000020000000 : "rootfs"
....
Poky (Yocto Project Reference Distro) 3.1.3 sam9x60ek ttyS0
....
root@sam9x60ek:~# cat /proc/partitions 
major minor  #blocks  name

   1        0       8192 ram0
   1        1       8192 ram1
   1        2       8192 ram2
   1        3       8192 ram3
  31        0        256 mtdblock0
  31        1        768 mtdblock1
  31        2        256 mtdblock2
  31        3        256 mtdblock3
  31        4        512 mtdblock4
  31        5       6144 mtdblock5
  31        6        256 mtdblock6
  31        7        768 mtdblock7
  31        8        256 mtdblock8
  31        9        256 mtdblock9
  31       10       6656 mtdblock10
  31       11     516096 mtdblock11
```

Also the prebuilt package from [Demo archives](https://www.linux4sam.org/bin/view/Linux4SAM/Sam9x60EKMainPage#Demo_archives) seem to confirm this, so I would propose to fix it.