### PR TITLE
udev-rules-at91: Update common-licenses references to match new names

### DIFF
--- a/recipes-core/udev-at91/udev-rules-at91.bb
+++ b/recipes-core/udev-at91/udev-rules-at91.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "Extra udev rules for AT91 boards"
 LICENSE = "GPLv2+"
-LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0-or-later;md5=fed54355545ffd980b814dab4a3b312c"
 
 SRC_URI = " file://keyboard.rules"
 


### PR DESCRIPTION
The licenses were renamed to match their SPDX names, fix the
references in LIC_FILES_CHKSUM.

Signed-off-by: Khem Raj <raj.khem@gmail.com>