### PR TITLE
libegt: Search OE aclocal before local m4 files

### DIFF
--- a/recipes-graphics/libegt/libegt_1.1.bb
+++ b/recipes-graphics/libegt/libegt_1.1.bb
@@ -28,6 +28,8 @@ inherit pkgconfig autotools gettext
 
 EXTRA_OECONF += "--disable-debug"
 
+EXTRA_AUTORECONF_append = " -I ${STAGING_DATADIR}/aclocal"
+
 PACKAGECONFIG ??= "examples icons plplot curl librsvg gstreamer jpeg zlib libinput lua ${@bb.utils.filter('DISTRO_FEATURES', 'x11 alsa', d)}"
 
 PACKAGECONFIG[librsvg] = "--with-librsvg,-without-librsvg,librsvg"


### PR DESCRIPTION
To use latest gcc/clang etc we need fixes like

https://git.savannah.gnu.org/gitweb/?p=autoconf-archive.git;a=commit;h=9e917efe603b0d756f258cad6eb2056559284ed0

Since the tests in these m4 needs updated code snippets the older
snippets are flagged as warnings/errors during test compile, resulting
in configure tests resulting in failures

Signed-off-by: Khem Raj <raj.khem@gmail.com>