### PR TITLE
Update git:// to https:// for at91bootstrap repo

### DIFF
--- a/recipes-bsp/at91bootstrap/at91bootstrap_git.bb
+++ b/recipes-bsp/at91bootstrap/at91bootstrap_git.bb
@@ -3,7 +3,7 @@ require at91bootstrap.inc
 DEFAULT_PREFERENCE = "-1"
 
 SRCREV = "${AUTOREV}"
-SRC_URI = "${@bb.utils.contains('BB_NO_NETWORK', '1', '', 'git://github.com/linux4sam/at91bootstrap.git;protocol=git', d)}"
+SRC_URI = "${@bb.utils.contains('BB_NO_NETWORK', '1', '', 'https://github.com/linux4sam/at91bootstrap.git;protocol=git', d)}"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
See https://github.blog/2021-09-01-improving-git-protocol-security-github/ for reason