### PR TITLE
sam-ba: fix download issue

### DIFF
--- a/recipes-devtools/sam-ba/sam-ba_3.3.1.bb
+++ b/recipes-devtools/sam-ba/sam-ba_3.3.1.bb
@@ -4,7 +4,7 @@ LICENSE = "GPL-2.0"
 
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
-SRC_URI = "https://github.com/atmelcorp/${BPN}/releases/download/v${PV}/${BPN}_${PV}-linux_x86_64.tar.gz"
+SRC_URI = "https://www.microchip.com/content/dam/mchp/documents/MPU32/ProductDocuments/SoftwareTools/${BPN}_${PV}-linux_x86_64.tar.gz"
 SRC_URI[md5sum] = "54f9c25b18a2a1afe2735b5da38e7580"
 SRC_URI[sha256sum] = "dc32c49688bbfab5aa687042caae5f611fe3d9e722098a561f8f5d2fbc57249d"
 


### PR DESCRIPTION
the most recent version of Microchip's SAM-BA programming tool is no longer hosted
on GitHub. Therefore the package is downloaded from Microchip directly.

Fixes:

ERROR: sam-ba-native-3.3.1-r0 do_fetch: Fetcher failure: Fetch command export PSEUDO_DISABLED=1; export GIT_PROXY_COMMAND="oe-git-proxy"; export NO_PROXY="*"; export PATH="/work/poky/scripts/native-intercept:/build/tmp/sysroots-uninative/x86_64-linux/usr/bin:/work/poky/scripts:/build/tmp/work/x86_64-linux/sam-ba-native/3.3.1-r0/recipe-sysroot-native/usr/bin/x86_64-linux:/build/tmp/work/x86_64-linux/sam-ba-native/3.3.1-r0/recipe-sysroot-native/usr/bin:/build/tmp/work/x86_64-linux/sam-ba-native/3.3.1-r0/recipe-sysroot-native/usr/sbin:/build/tmp/work/x86_64-linux/sam-ba-native/3.3.1-r0/recipe-sysroot-native/usr/bin:/build/tmp/work/x86_64-linux/sam-ba-native/3.3.1-r0/recipe-sysroot-native/sbin:/build/tmp/work/x86_64-linux/sam-ba-native/3.3.1-r0/recipe-sysroot-native/bin:/work/poky/bitbake/bin:/build/tmp/hosttools"; export HOME="/tmp/tmphe_cqe9q"; /usr/bin/env wget -t 2 -T 30 --passive-ftp --no-check-certificate -P /build/tmp/work/x86_64-linux/sam-ba-native/downloads 'https://github.com/atmelcorp/sam-ba/releases/download/v3.3.1/sam-ba_3.3.1-linux_x86_64.tar.gz' --progress=dot -v failed with exit code 8, output:
--2021-11-02 20:15:13--  https://github.com/atmelcorp/sam-ba/releases/download/v3.3.1/sam-ba_3.3.1-linux_x86_64.tar.gz
Resolving github.com (github.com)... 140.82.121.4
Connecting to github.com (github.com)|140.82.121.4|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2021-11-02 20:15:14 ERROR 404: Not Found.

Signed-off-by: Pierre-Jean Texier <pierre-jean.texier@lafon.fr>