### PR TITLE
plplot: fixed several acquisition and licensing issues

### DIFF
--- a/recipes-support/plplot/plplot_5.15.0.bb
+++ b/recipes-support/plplot/plplot_5.15.0.bb
@@ -2,15 +2,14 @@ DESCRIPTION = "plplot library"
 HOMEPAGE = "http://plplot.org/"
 SECTION = "devel"
 
-LICENSE = "LGPLv2+"
-LIC_FILES_CHKSUM = "file://Copyright;endline=285;md5=9222bd6b5e4e128fac952e168cffc361"
+LICENSE = "GPLv2+"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6"
 
 DEPENDS = " libtool freetype fontconfig cairo pango "
 
-#TAG plplot-5.15.0
-SRCREV = "4f88e45dbd85468a96364548f8d06a9b52dac14a"
-
-SRC_URI = "git://github.com/PLplot/PLplot;protocol=https \
+# TAG plplot-5.15.0
+SRC_URI = " \
+    https://github.com/PLplot/PLplot/archive/refs/tags/${PN}-${PV}.zip;protocol=https \
     file://0001-plplot-fix-configure-error-for-generating-header-fil.patch \
     file://0002-utils-CMakeLists.txt-disable-pltek-build.patch \
     file://0001-xwin.cmake-Check-if-PTHREAD_MUTEX_RECURSIVE_NP-exist.patch \
@@ -19,7 +18,9 @@ SRC_URI = "git://github.com/PLplot/PLplot;protocol=https \
     file://plhershey-unicode.h \
 "
 
-S = "${WORKDIR}/git"
+SRC_URI[sha256sum] = "2d98caa088a74d4f89e80cf2b347897d79964fd62d0957996a6aea9ca06c99c1"
+
+S = "${WORKDIR}/PLplot-${PN}-${PV}"
 
 EXTRA_OECMAKE += " \
     -DCMAKE_INSTALL_LIBDIR=${libdir} \


### PR DESCRIPTION
This commit resolves several problems related to the plplot library detected in the compilation of the sama5d2-xplained machine.

```
afinfante@fenix:~/poky/build$ sync && bitbake microchip-graphics-image
Loading cache: 100% |######################################################################################################################################################################################################################################| Time: 0:00:02
Loaded 3386 entries from dependency cache.
Parsing recipes: 100% |####################################################################################################################################################################################################################################| Time: 0:00:02
Parsing of 2277 .bb files complete (2275 cached, 2 parsed). 3387 targets, 349 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.46.0"
BUILD_SYS            = "i686-linux"
NATIVELSBSTRING      = "universal"
TARGET_SYS           = "arm-poky-linux-gnueabi"
MACHINE              = "sama5d2-xplained"
DISTRO               = "poky-atmel"
DISTRO_VERSION       = "3.1.13"
TUNE_FEATURES        = "arm vfp cortexa5 neon vfpv4 thumb callconvention-hard"
TARGET_FPU           = "hard"
meta                 
meta-poky            
meta-yocto-bsp       = "dunfell:795339092f87672e4f68e4d3bc4cfd0e252d1831"
meta-atmel           = "dunfell:20eeec4910f1214b9099f5276a944e5d281b70ee"
meta-oe              
meta-networking      
meta-python          
meta-multimedia      = "dunfell:69f94af4d91215e7d4e225bab54bf3bcfee42f1c"
meta-qt5             = "dunfell:b4d24d70aca75791902df5cd59a4f4a54aa4a125"

Initialising tasks: 100% |#################################################################################################################################################################################################################################| Time: 0:00:21
Sstate summary: Wanted 1590 Found 180 Missed 1410 Current 842 (11% match, 42% complete)
NOTE: Executing Tasks
ERROR: plplot-5.15.0-r0 do_fetch: No checksum specified for '/home/afinfante/poky/build/downloads/PLplot', please add at least one to the recipe:
SRC_URI[sha256sum] = "6007e8dc067a435c79a9994d76efc9e5510a22923fe14e282975e09a7b719257"
ERROR: plplot-5.15.0-r0 do_fetch: Bitbake Fetcher Error: NoChecksumError('Missing SRC_URI checksum', 'https://github.com/PLplot/PLplot;protocol=https')
ERROR: Logfile of failure stored in: /home/afinfante/poky/build/tmp/work/cortexa5t2hf-neon-vfpv4-poky-linux-gnueabi/plp
````