### PR TITLE
kernel: Drop KBUILD_DEFCONFIG

### DIFF
--- a/conf/machine/include/sama7.inc
+++ b/conf/machine/include/sama7.inc
@@ -14,6 +14,3 @@ PREFERRED_PROVIDER_jpeg-native ?= "jpeg-native"
 
 SERIAL_CONSOLES ?= "115200;ttyS0"
 WIC_CREATE_EXTRA_ARGS ?= "--no-fstab-update"
-
-# default kernel defconfig
-KBUILD_DEFCONFIG = "sama7_defconfig"

--- a/conf/machine/sama7g5ek-emmc.conf
+++ b/conf/machine/sama7g5ek-emmc.conf
@@ -21,6 +21,7 @@ UBOOT_LOADADDRESS = "0x62000000"
 UBOOT_ENV_SIZE = "0x4000"
 
 AT91BOOTSTRAP_MACHINE ?= "sama7g5ek"
+KERNEL_CONFIG_COMMAND = "oe_runmake -C ${S} O=${B} sama7_defconfig"
 
 # Needed for FIT
 MACHINE_ESSENTIAL_EXTRA_RDEPENDS = " dt-overlay-mchp"

--- a/conf/machine/sama7g5ek-sd.conf
+++ b/conf/machine/sama7g5ek-sd.conf
@@ -21,6 +21,7 @@ UBOOT_LOADADDRESS = "0x62000000"
 UBOOT_ENV_SIZE = "0x4000"
 
 AT91BOOTSTRAP_MACHINE ?= "sama7g5ek"
+KERNEL_CONFIG_COMMAND = "oe_runmake -C ${S} O=${B} sama7_defconfig"
 
 # Needed for FIT
 MACHINE_ESSENTIAL_EXTRA_RDEPENDS = " dt-overlay-mchp"

--- a/recipes-kernel/linux/linux.inc
+++ b/recipes-kernel/linux/linux.inc
@@ -14,16 +14,6 @@ python __anonymous () {
         d.appendVar('DEPENDS', ' u-boot-mkimage-native dtc-native')
 }
 
-do_configure:prepend() {
-	if [ ! -f "${WORKDIR}/defconfig" ] && [ -n "${KBUILD_DEFCONFIG}" ]; then
-		if [ -f "${S}/arch/${ARCH}/configs/${KBUILD_DEFCONFIG}" ]; then
-			cp -f ${S}/arch/${ARCH}/configs/${KBUILD_DEFCONFIG} ${WORKDIR}/defconfig
-                else
-                        bbfatal "A KBUILD_DEFCONFIG '${KBUILD_DEFCONFIG}' was specified, but not present in the source tree"
-                fi
-        fi
-}
-
 do_configure:append() {
 	frags=""
 	for fragment in ${WORKDIR}/*.cfg


### PR DESCRIPTION
KBUILD_DEFCONFIG is confusing people, stop using it and simplify recipes

Signed-off-by: Alexandre Belloni <alexandre.belloni@bootlin.com>