### PR TITLE
egt-benchmark: Use gitsm fetcher

### DIFF
--- a/recipes-egt/apps/egt-benchmark_1.0.bb
+++ b/recipes-egt/apps/egt-benchmark_1.0.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://COPYING;endline=202;md5=3b83ef96387f14655fc854ddc3c6b
 
 DEPENDS = "libegt"
 
-SRC_URI = "git://github.com/linux4sam/egt-benchmark.git;protocol=https;branch=master"
+SRC_URI = "gitsm://github.com/linux4sam/egt-benchmark.git;protocol=https;branch=master"
 
 SRCREV = "be25417177e874d1a665705a86dfaa25458f64ac"
 


### PR DESCRIPTION
It houses hayai as a submodule, and it fails to build because hayai.h is missing. The reason is that the sources are not fetched properly. therefore use gitsm fetcher so it can fetch the hayai submodule and use it during build

Fixes
'./'`src/main.cpp
src/main.cpp:7:10: fatal error: 'hayai.hpp' file not found
         ^~~~~~~~~~~
1 error generated.
make[1]: *** [Makefile:513: src/benchmark-main.o] Error 1

Signed-off-by: Khem Raj <raj.khem@gmail.com>