### PR TITLE
Fix libegt/egt-launcher with clang/libc++

### DIFF
--- a/recipes-egt/apps/egt-launcher_1.2.bb
+++ b/recipes-egt/apps/egt-launcher_1.2.bb
@@ -12,7 +12,8 @@ DEPENDS = "libegt"
 RDEPENDS:${PN} = "evtest"
 
 SRC_URI = "git://github.com/linux4sam/egt-launcher.git;protocol=https;branch=master \
-	  file://0001-launch.sh-Use-start-stop-daemon-to-restart-egt.patch"
+           file://0001-launcher-Switch-to-using-std-filesystem.patch \
+	   file://0001-launch.sh-Use-start-stop-daemon-to-restart-egt.patch"
 
 PV = "1.2+git${SRCPV}"
 SRCREV = "529465ba53c5a0b68a0027ee149f75108557c351"

--- a/recipes-egt/apps/files/0001-launcher-Switch-to-using-std-filesystem.patch
+++ b/recipes-egt/apps/files/0001-launcher-Switch-to-using-std-filesystem.patch
@@ -1,0 +1,40 @@
+From 6a9542ff552689e80aae913d12282ae21c9c5c82 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sat, 7 Jan 2023 19:07:28 -0800
+Subject: [PATCH] launcher: Switch to using std::filesystem
+
+experimental/filesystem is promoted to std::filesystem and is must have
+with c++17 and newer standard, some compilers e.g. libcxx with
+llvm/clang 15+ has already dropped experimental/filesystem and expect
+one to use std::filesystem
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ src/launcher.cpp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/launcher.cpp b/src/launcher.cpp
+index 35afa0f..c6d583d 100644
+--- a/src/launcher.cpp
++++ b/src/launcher.cpp
+@@ -12,7 +12,7 @@
+ #include <cmath>
+ #include <egt/detail/filesystem.h>
+ #include <egt/ui>
+-#include <experimental/filesystem>
++#include <filesystem>
+ #include <fstream>
+ #include <iostream>
+ #include <memory>
+@@ -121,7 +121,7 @@ private:
+     SwipeCallback m_callback;
+ };
+ 
+-namespace filesys = std::experimental::filesystem;
++namespace filesys = std::filesystem;
+ 
+ /*
+  * Execute a command.
+-- 
+2.39.0
+

--- a/recipes-graphics/libegt/libegt/0001-Use-std-filesystem-instead-of-std-experimental-files.patch
+++ b/recipes-graphics/libegt/libegt/0001-Use-std-filesystem-instead-of-std-experimental-files.patch
@@ -1,0 +1,101 @@
+From 7c3c6e07199af92e6d3c2efa0696142b2e493ebb Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sat, 7 Jan 2023 18:58:21 -0800
+Subject: [PATCH] Use std::filesystem instead of std::experimental::filesystem
+
+filesystem support is in main runtime for many years now.
+Clang 15+ has dropped experimental/filesystem
+and now c++17 is asked explicitly so we can be confident of
+filesystem support in c++ standard runtime, therefore adjust accordingly
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ examples/dialog/dialog.cpp      | 4 ++--
+ src/detail/filesystem.cpp       | 6 ++----
+ src/detail/screen/kmsscreen.cpp | 6 ++----
+ src/filedialog.cpp              | 4 ++--
+ 4 files changed, 8 insertions(+), 12 deletions(-)
+
+diff --git a/examples/dialog/dialog.cpp b/examples/dialog/dialog.cpp
+index b0725f67..fafcfad2 100644
+--- a/examples/dialog/dialog.cpp
++++ b/examples/dialog/dialog.cpp
+@@ -4,11 +4,11 @@
+  * SPDX-License-Identifier: Apache-2.0
+  */
+ #include <egt/ui>
+-#include <experimental/filesystem>
++#include <filesystem>
+ #include <memory>
+ #include <string>
+ 
+-namespace fs = std::experimental::filesystem;
++namespace fs = std::filesystem;
+ 
+ int main(int argc, char** argv)
+ {
+diff --git a/src/detail/filesystem.cpp b/src/detail/filesystem.cpp
+index 5f9e404c..e1fc3c20 100644
+--- a/src/detail/filesystem.cpp
++++ b/src/detail/filesystem.cpp
+@@ -11,6 +11,7 @@
+ #include "egt/detail/filesystem.h"
+ #include <climits>
+ #include <cstring>
++#include <filesystem>
+ #include <fstream>
+ #include <iterator>
+ #include <libgen.h>
+@@ -23,10 +24,7 @@
+ #include <glob.h>
+ #endif
+ 
+-#ifdef HAVE_EXPERIMENTAL_FILESYSTEM
+-#include <experimental/filesystem>
+-namespace fs = std::experimental::filesystem;
+-#endif
++namespace fs = std::filesystem;
+ 
+ #ifdef HAVE_WINDOWS_H
+ #include <cstdio>
+diff --git a/src/detail/screen/kmsscreen.cpp b/src/detail/screen/kmsscreen.cpp
+index 3958a556..3c2973f2 100644
+--- a/src/detail/screen/kmsscreen.cpp
++++ b/src/detail/screen/kmsscreen.cpp
+@@ -29,11 +29,9 @@
+ #include <cairo-gfx2d.h>
+ #endif
+ 
+-#ifdef HAVE_EXPERIMENTAL_FILESYSTEM
+-#include <experimental/filesystem>
++#include <filesystem>
+ 
+-namespace fs = std::experimental::filesystem;
+-#endif
++namespace fs = std::filesystem;
+ 
+ namespace egt
+ {
+diff --git a/src/filedialog.cpp b/src/filedialog.cpp
+index 850bd598..e84bcd80 100644
+--- a/src/filedialog.cpp
++++ b/src/filedialog.cpp
+@@ -6,13 +6,13 @@
+ #include "detail/egtlog.h"
+ #include "egt/embed.h"
+ #include "egt/filedialog.h"
+-#include <experimental/filesystem>
++#include <filesystem>
+ 
+ #ifdef SRCDIR
+ EGT_EMBED(internal_folder, SRCDIR "/icons/32px/folder.png")
+ #endif
+ 
+-namespace fs = std::experimental::filesystem;
++namespace fs = std::filesystem;
+ 
+ namespace egt
+ {
+-- 
+2.39.0
+

--- a/recipes-graphics/libegt/libegt_1.6.bb
+++ b/recipes-graphics/libegt/libegt_1.6.bb
@@ -19,7 +19,9 @@ DEPENDS = "\
     xxd-native \
 "
 
-SRC_URI = "gitsm://github.com/linux4sam/egt.git;protocol=https;branch=1.6"
+SRC_URI = "gitsm://github.com/linux4sam/egt.git;protocol=https;branch=1.6 \
+           file://0001-Use-std-filesystem-instead-of-std-experimental-files.patch \
+          "
 
 SRCREV = "b1236ef56cc531c21813c9aa796584d1ba9e88fd"
 


### PR DESCRIPTION
@noglitch support for std::filesystem is still needed to get the latest libegt working. using c++17 is fixed in this version which is great but code for experimental::filesystem also needs to change