### PR TITLE
python3-cryptoauthlib: Update to 20221114

### DIFF
--- a/recipes-support/python-cryptoauthlib/python3-cryptoauthlib/0001-atca_iface.h-Fix-function-mismatches-in-function-poi.patch
+++ b/recipes-support/python-cryptoauthlib/python3-cryptoauthlib/0001-atca_iface.h-Fix-function-mismatches-in-function-poi.patch
@@ -1,0 +1,74 @@
+From 0b76ffe124719f96fe8bc3daf6410cf3198309f4 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Mon, 13 Feb 2023 22:07:10 -0800
+Subject: [PATCH] atca_iface.h: Fix function mismatches in function pointers
+
+Newer compilers e.g. clang16 can detect signature mismatches in the
+functions used as function pointers, therefore correct the function
+prototypes and ensure the typedefs they use are available at the time of
+use
+
+Fixes
+lib/hal/atca_hal.c:310:33: error: incompatible function pointer types       assigning to 'ATCA_STATUS (*)(ATCAIface, ATCAIfaceCfg *)' (aka 'ATCA_STATUS (*)(struct atca_iface *, ATCAIfaceCfg *)') from 'ATCA_STATUS (*)(void *, void *)' [-Wincompatible-function-      pointer-types]
+                 (*hal)->halinit = cfg->atcacustom.halinit;
+                                 ^ ~~~~~~~~~~~~~~~~~~~~~~~
+
+Upstream-Status: Submitted [https://github.com/MicrochipTech/cryptoauthlib/pull/330]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ lib/atca_iface.h | 21 +++++++++------------
+ 1 file changed, 9 insertions(+), 12 deletions(-)
+
+diff --git a/lib/atca_iface.h b/lib/atca_iface.h
+index 9dfc422..e669b33 100644
+--- a/lib/atca_iface.h
++++ b/lib/atca_iface.h
+@@ -81,11 +81,12 @@ typedef enum
+     ATCA_KIT_SPI_IFACE,
+     ATCA_KIT_UNKNOWN_IFACE } ATCAKitType;
+ 
++typedef struct atca_iface * ATCAIface;
+ 
+ /* ATCAIfaceCfg is the configuration object for a device
+  */
+ 
+-typedef struct
++typedef struct ATCAIfaceCfgType
+ {
+ 
+     ATCAIfaceType  iface_type;      // active iface - how to interpret the union below
+@@ -147,13 +148,13 @@ typedef struct
+ 
+         struct
+         {
+-            ATCA_STATUS (*halinit)(void *hal, void *cfg);
+-            ATCA_STATUS (*halpostinit)(void *iface);
+-            ATCA_STATUS (*halsend)(void *iface, uint8_t word_address, uint8_t *txdata, int txlength);
+-            ATCA_STATUS (*halreceive)(void *iface, uint8_t word_address, uint8_t* rxdata, uint16_t* rxlength);
+-            ATCA_STATUS (*halwake)(void *iface);
+-            ATCA_STATUS (*halidle)(void *iface);
+-            ATCA_STATUS (*halsleep)(void *iface);
++            ATCA_STATUS (*halinit)(ATCAIface hal, struct ATCAIfaceCfgType* cfg);
++            ATCA_STATUS (*halpostinit)(ATCAIface iface);
++            ATCA_STATUS (*halsend)(ATCAIface iface, uint8_t word_address, uint8_t *txdata, int txlength);
++            ATCA_STATUS (*halreceive)(ATCAIface iface, uint8_t word_address, uint8_t* rxdata, uint16_t* rxlength);
++            ATCA_STATUS (*halwake)(ATCAIface iface);
++            ATCA_STATUS (*halidle)(ATCAIface iface);
++            ATCA_STATUS (*halsleep)(ATCAIface iface);
+             ATCA_STATUS (*halrelease)(void* hal_data);
+         } atcacustom;
+     } ATCA_IFACECFG_NAME(cfg);
+@@ -163,10 +164,6 @@ typedef struct
+     void *   cfg_data;      // opaque data used by HAL in device discovery
+ } ATCAIfaceCfg;
+ 
+-
+-
+-typedef struct atca_iface * ATCAIface;
+-
+ /** \brief HAL Driver Structure
+  */
+ typedef struct
+-- 
+2.39.1
+

--- a/recipes-support/python-cryptoauthlib/python3-cryptoauthlib/0001-correct-the-python_requires-version-syntax.patch
+++ b/recipes-support/python-cryptoauthlib/python3-cryptoauthlib/0001-correct-the-python_requires-version-syntax.patch
@@ -1,0 +1,29 @@
+From 3138909f544e24cee6b14134148c22215816b15e Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Mon, 13 Feb 2023 16:55:42 -0800
+Subject: [PATCH] correct the python_requires version syntax
+
+Fixes errors like
+'python_requires' must be a string containing valid version specifiers; Invalid specifier: '>=3.4.*'
+
+Upstream-Status: Submitted [https://github.com/MicrochipTech/cryptoauthlib/pull/330]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ setup.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/setup.py b/setup.py
+index 706574c..c06593b 100644
+--- a/setup.py
++++ b/setup.py
+@@ -231,6 +231,6 @@ if __name__ == '__main__':
+         setup_requires=['setuptools>=38.6.0', 'wheel'],
+         install_requires=['enum34;python_version<"3.4"'],
+         ext_modules=_EXTENSIONS,
+-        python_requires='>=3.4.*',
++        python_requires='>=3.4.0',
+         zip_safe=False
+     )
+-- 
+2.39.1
+

--- a/recipes-support/python-cryptoauthlib/python3-cryptoauthlib_20221114.bb
+++ b/recipes-support/python-cryptoauthlib/python3-cryptoauthlib_20221114.bb
@@ -4,13 +4,11 @@ HOMEPAGE = "https://github.com/MicrochipTech/cryptoauthlib"
 LICENSE = "CLOSED"
 LIC_FILES_CHKSUM = ""
 
-SRC_URI = "https://files.pythonhosted.org/packages/1b/ed/da1709095abd203e37892f7183b68433382ce6a0f6129dfa0ac47e2ba85c/cryptoauthlib-${PV}.tar.gz \
-           ${PYPI_SRC_URI} \
-           "
-SRC_URI[md5sum] = "3a464cb6ea78286353870e544f85e208"
-SRC_URI[sha256sum] = "7b04a4097c6f8d4b539c7425261eac3353016405b863fec2d827152ce3a652bf"
-
 inherit pypi setuptools3
+
+SRC_URI += "file://0001-correct-the-python_requires-version-syntax.patch \
+            file://0001-atca_iface.h-Fix-function-mismatches-in-function-poi.patch"
+SRC_URI[sha256sum] = "cc63dba63f1983c12ad18ecb3f1595083feffc0cb827d2a8d3a54c850d26ed5d"
 
 RDEPENDS:${PN} += "python3-core python3-cryptography python3-ctypes python3-datetime python3-netclient"
 


### PR DESCRIPTION
Fix build with latest setuptools and compiler errors seens with clang 16

Signed-off-by: Khem Raj <raj.khem@gmail.com>