### PR TITLE
egt-samples-contribution_1.1.bb: Inherit from missing siteinfo class

### DIFF
--- a/recipes-egt/apps/egt-samples-contribution_1.1.bb
+++ b/recipes-egt/apps/egt-samples-contribution_1.1.bb
@@ -18,7 +18,7 @@ S = "${WORKDIR}/git"
 
 EXTRA_OECMAKE += "-DEGT_SAMPLES_CONTRIBUTION_SLIDERB=true"
 
-inherit pkgconfig cmake
+inherit pkgconfig cmake siteinfo
 
 python __anonymous () {
     endianness = d.getVar('SITEINFO_ENDIANNESS')


### PR DESCRIPTION
Since we use SITEINFO_ENDIANNESS this class is required or else this recipe will be parsed but wont find libegl and fail with errors like

ERROR: Nothing PROVIDES 'libegt' (but /mnt/jenkins/workspace/yocto-world-glibc/sources/meta-atmel/recipes-egt/apps/egt-samples-contribution_1.1.bb DEPENDS on or otherwise requires it) libegt was skipped: Requires little-endian target. libegt was skipped: Requires little-endian target. ERROR: Nothing RPROVIDES 'egt-samples-contribution' (but /mnt/jenkins/workspace/yocto-world-glibc/sources/meta-atmel/recipes-egt/apps/egt-samples-contribution_1.1.bb RDEPENDS on or otherwise requires it) No eligible RPROVIDERs exist for 'egt-samples-contribution' NOTE: Runtime target 'egt-samples-contribution' is unbuildable, removing... Missing or unbuildable dependency chain was: ['egt-samples-contribution']