### PR TITLE
Use bbnote instead echo in tasks

### DIFF
--- a/recipes-bsp/dt-overlay-mchp/dt-overlay-mchp_git.bb
+++ b/recipes-bsp/dt-overlay-mchp/dt-overlay-mchp_git.bb
@@ -27,24 +27,24 @@ do_compile[nostamp] = "1"
 do_compile () {
     # Check to properly identify the board
     if [ -z "${AT91BOOTSTRAP_MACHINE}" ]; then
-        echo "No AT91BOOTSTRAP_MACHINE set for ${MACHINE}"
+        bbnote "No AT91BOOTSTRAP_MACHINE set for ${MACHINE}"
         exit 1
     fi
 
     if [ -d "${AT91BOOTSTRAP_MACHINE}" ]; then
-        echo "Compiling DTBOs"
+        bbnote "Compiling DTBOs"
         oe_runmake DTC=dtc KERNEL_DIR=${STAGING_KERNEL_DIR} KERNEL_BUILD_DIR=${KERNEL_PATH} ${AT91BOOTSTRAP_MACHINE}_dtbos
     else
-        echo "No DTBOs to compile"
+        bbnote "No DTBOs to compile"
     fi
 
     # Over-ride itb target in Makefile
     if [ -e "${AT91BOOTSTRAP_MACHINE}.its" ]; then
-        echo "Creating the FIT image"
+        bbnote "Creating the FIT image"
         DTC_OPTIONS="-Wno-unit_address_vs_reg -Wno-graph_child_address -Wno-pwms_property"
         mkimage -D "-i${DEPLOY_DIR_IMAGE} -p 1000 ${DTC_OPTIONS}" -f ${AT91BOOTSTRAP_MACHINE}.its ${AT91BOOTSTRAP_MACHINE}.itb
     else
-        echo "No its file to create FIT images"
+        bbnote "No its file to create FIT images"
     fi
 }
 
@@ -69,7 +69,7 @@ do_install () {
 addtask deploy after do_install
 
 do_deploy () {
-    #echo "Copying ${fit_image_basename}.itb and source file to ${DEPLOYDIR}..."
+    #bbnote "Copying ${fit_image_basename}.itb and source file to ${DEPLOYDIR}..."
     if [ -e ${AT91BOOTSTRAP_MACHINE}.itb ]; then
         install ${AT91BOOTSTRAP_MACHINE}.itb ${DEPLOYDIR}/
         install ${AT91BOOTSTRAP_MACHINE}.its ${DEPLOYDIR}/

--- a/recipes-bsp/u-boot/u-boot-envs-atmel.inc
+++ b/recipes-bsp/u-boot/u-boot-envs-atmel.inc
@@ -7,10 +7,10 @@ ENV_FILEPATH = "${WORKDIR}/envs"
 
 do_compile:append() {
     if [ -e "${ENV_FILEPATH}/${MACHINE}.txt" ]; then
-        echo "Compile U-Boot environment for ${MACHINE}"
+        bbnote "Compile U-Boot environment for ${MACHINE}"
         ${B}/tools/mkenvimage ${MKENVIMAGE_EXTRA_ARGS} -s ${UBOOT_ENV_SIZE} ${ENV_FILEPATH}/${MACHINE}.txt -o ${ENV_FILENAME}
     else
-        echo "No custom environment available for ${MACHINE}."
+        bbnote "No custom environment available for ${MACHINE}."
     fi
 }
 


### PR DESCRIPTION
The logging class that provides the standard shell functions used to log messages, that should be use in tasks (i.e. bbplain, bbnote, bbwarn, bberror, bbfatal, and bbdebug).

