### PR TITLE
pixman: indicate patch Upstream-Status

### DIFF
--- a/recipes-graphics/pixman/pixman/0001-Revert-Initialize-temporary-buffers-in-general_compo.patch
+++ b/recipes-graphics/pixman/pixman/0001-Revert-Initialize-temporary-buffers-in-general_compo.patch
@@ -10,6 +10,7 @@ causes performance issues with EGT:
 - Lower score for DrawFixture.MoveAnimate/UpdateButton for all devices.
 - egt_drop very slow for all devices.
 
+Upstream-Status: Inappropriate
 Signed-off-by: Ludovic Desroches <ludovic.desroches@microchip.com>
 ---
  pixman/pixman-general.c | 6 ------


### PR DESCRIPTION
pixman is included in openembedded-core, which applies a more strict patch-status QA check for the Upstream-Status.
To avoid build errors with the master Yocto and future releases the patches applied to openembedded-core should follow: https://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines