### PR TITLE
at91bootstrap: upgrade to 3.10.3

### DIFF
--- a/recipes-bsp/at91bootstrap/at91bootstrap_3.10.3.bb
+++ b/recipes-bsp/at91bootstrap/at91bootstrap_3.10.3.bb
@@ -6,8 +6,8 @@ COMPATIBLE_MACHINE = '(sama5d3xek|sama5d3-xplained|sama5d3-xplained-sd|at91sam9x
 
 SRC_URI = "git://github.com/linux4sam/at91bootstrap.git;protocol=https;branch=at91bootstrap-3.x"
 
-PV = "3.10.2+git${SRCPV}"
-SRCREV = "2edb4dd14120c7b6d5794e496ecabf274095d1f5"
+PV = "3.10.3+git${SRCPV}"
+SRCREV = "fcc51f8ddb4bb346debf1960f8ba04387169ecc0"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
The purpose of this Pull Request is to fix the "-nostartfiles" issue reported here: https://github.com/linux4sam/meta-atmel/issues/254

I'm upgrading to 3.10.3. Please note 3.10.4 is also available but another issue appears with it so I prefer to keep this one.