### PR TITLE
p11-kit: delete unnecessary bbappend

### DIFF
--- a/recipes-support/p11-kit/p11-kit_0.24.1.bbappend
+++ b/recipes-support/p11-kit/p11-kit_0.24.1.bbappend
@@ -1,1 +1,0 @@
-BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
The master meta-atmel cannot be built against master Yocto as the p11-kit was upgraded to 0.25.0.

There is no need to upgrade this bbappend as the upstream recipe already includes the required BBCLASSEXTEND, so we can simply delete the bbappend without any harm.
http://cgit.openembedded.org/openembedded-core/tree/meta/recipes-support/p11-kit/p11-kit_0.25.0.bb