### PR TITLE
layer.conf: add meta-arm in LAYERDEPENDS

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -7,7 +7,7 @@ BBFILES += "${LAYERDIR}/recipes*/*/*.bb ${LAYERDIR}/recipes*/*/*.bbappend"
 BBFILE_COLLECTIONS += "atmel"
 BBFILE_PATTERN_atmel := "^${LAYERDIR}/"
 BBFILE_PRIORITY_atmel = "10"
-LAYERDEPENDS_atmel = "openembedded-layer"
+LAYERDEPENDS_atmel = "openembedded-layer meta-arm"
 
 LICENSE_PATH += "${LAYERDIR}/licenses"
 


### PR DESCRIPTION
Because it provides OP-TEE recipes.