### PR TITLE
cryptoauthlib: add lfs=0 to SRC_URI to avoid git errors in do_unpack

### DIFF
--- a/recipes-security/cryptoauthlib/cryptoauthlib_git.bb
+++ b/recipes-security/cryptoauthlib/cryptoauthlib_git.bb
@@ -3,7 +3,7 @@ DESCRIPTION = "Microchip CryptoAuthentication Library"
 LICENSE = "MICROCHIP_CAL"
 LIC_FILES_CHKSUM = "file://license.txt;endline=18;md5=8f046e550ca998a71c7d7ceb7069ccee"
 
-SRC_URI = "git://github.com/MicrochipTech/cryptoauthlib.git;branch=main;protocol=https \
+SRC_URI = "git://github.com/MicrochipTech/cryptoauthlib.git;branch=main;protocol=https;lfs=0 \
            file://cryptoauthlib.module \
 	   file://0001-pkcs11-add-KeyLen-condition.patch \
            "


### PR DESCRIPTION
ERROR: cryptoauthlib-1.0+git-r0 do_fetch: Fetcher failure: Repository https://github.com/MicrochipTech/cryptoauthlib.git has LFS content, install git-lfs on host to download (or set lfs=0 to ignore it)