### PR TITLE
u-boot: add support of *.cfg files

### DIFF
--- a/recipes-bsp/u-boot/u-boot-atmel-configure.inc
+++ b/recipes-bsp/u-boot/u-boot-atmel-configure.inc
@@ -1,0 +1,39 @@
+# This provides the logic for creating the desired u-boot config,
+# accounting for any *.cfg files added to SRC_URI.  It's separated
+# from u-boot-atmel.inc for use by recipes that need u-boot properly
+# configured but aren't doing a full build of u-boot itself (such as
+# its companion tools).
+
+inherit uboot-config cml1
+
+DEPENDS += "kern-tools-native"
+
+do_configure () {
+    if [ -n "${UBOOT_CONFIG}" ]; then
+        unset i j
+        for config in ${UBOOT_MACHINE}; do
+            i=$(expr $i + 1);
+            for type in ${UBOOT_CONFIG}; do
+                j=$(expr $j + 1);
+                if [ $j -eq $i ]; then
+                    oe_runmake -C ${S} O=${B}/${config} ${config}
+                    if [ -n "${@' '.join(find_cfgs(d))}" ]; then
+                        merge_config.sh -m -O ${B}/${config} ${B}/${config}/.config ${@" ".join(find_cfgs(d))}
+                        oe_runmake -C ${S} O=${B}/${config} oldconfig
+                    fi
+                fi
+            done
+            unset j
+        done
+        unset i
+        DEVTOOL_DISABLE_MENUCONFIG=true
+    else
+        if [ -n "${UBOOT_MACHINE}" ]; then
+            oe_runmake -C ${S} O=${B} ${UBOOT_MACHINE}
+        else
+            oe_runmake -C ${S} O=${B} oldconfig
+        fi
+        merge_config.sh -m .config ${@" ".join(find_cfgs(d))}
+        cml1_do_configure
+    fi
+}

--- a/recipes-bsp/u-boot/u-boot-atmel.inc
+++ b/recipes-bsp/u-boot/u-boot-atmel.inc
@@ -30,6 +30,8 @@ SPL_BINARY ?= ""
 SPL_IMAGE ?= "${SPL_BINARY}-${MACHINE}-${PV}-${PR}"
 SPL_SYMLINK ?= "${SPL_BINARY}-${MACHINE}"
 
+require u-boot-atmel-configure.inc
+
 do_compile () {
 	if [ "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-gold', 'ld-is-gold', '', d)}" = "ld-is-gold" ] ; then
 		sed -i 's/$(CROSS_COMPILE)ld$/$(CROSS_COMPILE)ld.bfd/g' config.mk
@@ -45,7 +47,6 @@ do_compile () {
 		echo ${UBOOT_LOCALVERSION} > ${S}/.scmversion
 	fi
 
-	oe_runmake ${UBOOT_MACHINE}
 	oe_runmake ${UBOOT_MAKE_TARGET}
 }
 


### PR DESCRIPTION
Resolve the problem of support of .cfg configuration fragments. When a user adds a fragment.cfg to SRC_URI, it is expecetd that configuration is added to the final image, but it is not done.