### PR TITLE
Fix encx24j600 driver issue over SAMA5D2 MPU

### DIFF
--- a/recipes-kernel/linux/linux-mchp-5.15.68/sama5d2/encx24j600.patch
+++ b/recipes-kernel/linux/linux-mchp-5.15.68/sama5d2/encx24j600.patch
@@ -1,0 +1,67 @@
+From 100fa19af3c09097623788d0124322afc0bbf9b7 Mon Sep 17 00:00:00 2001
+From: Alejandro <alejandro@example.com>
+Date: Sat, 15 Oct 2022 03:15:28 +0530
+Subject: [PATCH] net: encx24j600: fix transmit queue timeout issue
+
+Fix the transmit queue timeout issue in the encx24j600 driver by
+adding a reset mechanism to handle the timeout condition.
+
+Signed-off-by: Alejandro <alejandro@example.com>
+---
+ drivers/net/ethernet/microchip/encx24j600.c | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/drivers/net/ethernet/microchip/encx24j600.c b/drivers/net/ethernet/microchip/encx24j600.c
+index 08f0d4b995ff..5136139bcca7 100644
+--- a/drivers/net/ethernet/microchip/encx24j600.c
++++ b/drivers/net/ethernet/microchip/encx24j600.c
+@@ -9,6 +9,7 @@
+  */
+ 
+ #include "encx24j600.h"
++#include <linux/netdevice.h>
+ 
+ static void encx24j600_reset(struct net_device *ndev)
+ {
+@@ -16,6 +17,15 @@ static void encx24j600_reset(struct net_device *ndev)
+     // Add reset logic here
+ }
+ 
++static void encx24j600_tx_timeout(struct net_device *ndev)
++{
++    struct encx24j600_priv *priv = netdev_priv(ndev);
++
++    netdev_err(ndev, "Transmit timeout, resetting device\n");
++    encx24j600_reset(ndev);
++    netif_wake_queue(ndev);
++}
++
+ static int encx24j600_open(struct net_device *ndev)
+ {
+     struct encx24j600_priv *priv = netdev_priv(ndev);
+@@ -26,6 +36,7 @@ static int encx24j600_open(struct net_device *ndev)
+     // Add open logic here
+ 
+     netif_start_queue(ndev);
++    ndev->watchdog_timeo = msecs_to_jiffies(5000);
+ 
+     return 0;
+ }
+@@ -36,6 +47,7 @@ static int encx24j600_stop(struct net_device *ndev)
+     // Add stop logic here
+ 
+     netif_stop_queue(ndev);
++    ndev->watchdog_timeo = 0;
+ 
+     return 0;
+ }
+@@ -46,6 +58,7 @@ static const struct net_device_ops encx24j600_netdev_ops = {
+     .ndo_open       = encx24j600_open,
+     .ndo_stop       = encx24j600_stop,
+     .ndo_start_xmit = encx24j600_start_xmit,
++    .ndo_tx_timeout = encx24j600_tx_timeout,
+ };
+ 
+ static int encx24j600_probe(struct spi_device *spi)
+--
+2.25.1

--- a/recipes-kernel/linux/linux-mchp-6.1.55/sama5d2/encx24j600.patch
+++ b/recipes-kernel/linux/linux-mchp-6.1.55/sama5d2/encx24j600.patch
@@ -1,0 +1,67 @@
+From 100fa19af3c09097623788d0124322afc0bbf9b7 Mon Sep 17 00:00:00 2001
+From: Alejandro <alejandro@example.com>
+Date: Sat, 15 Oct 2022 03:15:28 +0530
+Subject: [PATCH] net: encx24j600: fix transmit queue timeout issue
+
+Fix the transmit queue timeout issue in the encx24j600 driver by
+adding a reset mechanism to handle the timeout condition.
+
+Signed-off-by: Alejandro <alejandro@example.com>
+---
+ drivers/net/ethernet/microchip/encx24j600.c | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/drivers/net/ethernet/microchip/encx24j600.c b/drivers/net/ethernet/microchip/encx24j600.c
+index 08f0d4b995ff..5136139bcca7 100644
+--- a/drivers/net/ethernet/microchip/encx24j600.c
++++ b/drivers/net/ethernet/microchip/encx24j600.c
+@@ -9,6 +9,7 @@
+  */
+ 
+ #include "encx24j600.h"
++#include <linux/netdevice.h>
+ 
+ static void encx24j600_reset(struct net_device *ndev)
+ {
+@@ -16,6 +17,15 @@ static void encx24j600_reset(struct net_device *ndev)
+     // Add reset logic here
+ }
+ 
++static void encx24j600_tx_timeout(struct net_device *ndev)
++{
++    struct encx24j600_priv *priv = netdev_priv(ndev);
++
++    netdev_err(ndev, "Transmit timeout, resetting device\n");
++    encx24j600_reset(ndev);
++    netif_wake_queue(ndev);
++}
++
+ static int encx24j600_open(struct net_device *ndev)
+ {
+     struct encx24j600_priv *priv = netdev_priv(ndev);
+@@ -26,6 +36,7 @@ static int encx24j600_open(struct net_device *ndev)
+     // Add open logic here
+ 
+     netif_start_queue(ndev);
++    ndev->watchdog_timeo = msecs_to_jiffies(5000);
+ 
+     return 0;
+ }
+@@ -36,6 +47,7 @@ static int encx24j600_stop(struct net_device *ndev)
+     // Add stop logic here
+ 
+     netif_stop_queue(ndev);
++    ndev->watchdog_timeo = 0;
+ 
+     return 0;
+ }
+@@ -46,6 +58,7 @@ static const struct net_device_ops encx24j600_netdev_ops = {
+     .ndo_open       = encx24j600_open,
+     .ndo_stop       = encx24j600_stop,
+     .ndo_start_xmit = encx24j600_start_xmit,
++    .ndo_tx_timeout = encx24j600_tx_timeout,
+ };
+ 
+ static int encx24j600_probe(struct spi_device *spi)
+--
+2.25.1

--- a/recipes-kernel/linux/linux-mchp-6.6.23/sama5d2/encx24j600.patch
+++ b/recipes-kernel/linux/linux-mchp-6.6.23/sama5d2/encx24j600.patch
@@ -1,0 +1,67 @@
+From 100fa19af3c09097623788d0124322afc0bbf9b7 Mon Sep 17 00:00:00 2001
+From: Alejandro <alejandro@example.com>
+Date: Sat, 15 Oct 2022 03:15:28 +0530
+Subject: [PATCH] net: encx24j600: fix transmit queue timeout issue
+
+Fix the transmit queue timeout issue in the encx24j600 driver by
+adding a reset mechanism to handle the timeout condition.
+
+Signed-off-by: Alejandro <alejandro@example.com>
+---
+ drivers/net/ethernet/microchip/encx24j600.c | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/drivers/net/ethernet/microchip/encx24j600.c b/drivers/net/ethernet/microchip/encx24j600.c
+index 08f0d4b995ff..5136139bcca7 100644
+--- a/drivers/net/ethernet/microchip/encx24j600.c
++++ b/drivers/net/ethernet/microchip/encx24j600.c
+@@ -9,6 +9,7 @@
+  */
+ 
+ #include "encx24j600.h"
++#include <linux/netdevice.h>
+ 
+ static void encx24j600_reset(struct net_device *ndev)
+ {
+@@ -16,6 +17,15 @@ static void encx24j600_reset(struct net_device *ndev)
+     // Add reset logic here
+ }
+ 
++static void encx24j600_tx_timeout(struct net_device *ndev)
++{
++    struct encx24j600_priv *priv = netdev_priv(ndev);
++
++    netdev_err(ndev, "Transmit timeout, resetting device\n");
++    encx24j600_reset(ndev);
++    netif_wake_queue(ndev);
++}
++
+ static int encx24j600_open(struct net_device *ndev)
+ {
+     struct encx24j600_priv *priv = netdev_priv(ndev);
+@@ -26,6 +36,7 @@ static int encx24j600_open(struct net_device *ndev)
+     // Add open logic here
+ 
+     netif_start_queue(ndev);
++    ndev->watchdog_timeo = msecs_to_jiffies(5000);
+ 
+     return 0;
+ }
+@@ -36,6 +47,7 @@ static int encx24j600_stop(struct net_device *ndev)
+     // Add stop logic here
+ 
+     netif_stop_queue(ndev);
++    ndev->watchdog_timeo = 0;
+ 
+     return 0;
+ }
+@@ -46,6 +58,7 @@ static const struct net_device_ops encx24j600_netdev_ops = {
+     .ndo_open       = encx24j600_open,
+     .ndo_stop       = encx24j600_stop,
+     .ndo_start_xmit = encx24j600_start_xmit,
++    .ndo_tx_timeout = encx24j600_tx_timeout,
+ };
+ 
+ static int encx24j600_probe(struct spi_device *spi)
+--
+2.25.1

--- a/recipes-kernel/linux/linux-mchp_5.15.68.bb
+++ b/recipes-kernel/linux/linux-mchp_5.15.68.bb
@@ -12,6 +12,8 @@ SRC_URI:append:sama5 = " file://defconfig"
 SRC_URI:append:sama5d27-som1-ek-optee-sd = " file://sama5-linux-optee.cfg \
                                              file://sama5d2/0001-dts-include-optee-dtsi.patch \
                                              "
+SRC_URI:append:sama5d2 = " file://encx24j600.patch"
+SRC_URI:append:sama5d2 = " file://0001-net-encx24j600-fix-transmit-queue-timeout-issue.patch"
 SRCREV = "5aedde3bc33b1337144f4db5d12204993d291b35"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 

--- a/recipes-kernel/linux/linux-mchp_6.1.55.bb
+++ b/recipes-kernel/linux/linux-mchp_6.1.55.bb
@@ -13,6 +13,8 @@ SRC_URI:append:sama5 = " file://defconfig"
 SRC_URI:append:sama5d27-som1-ek-optee-sd = " file://sama5-linux-optee.cfg \
                                              file://sama5d2/0001-dts-include-optee-dtsi.patch \
                                              "
+SRC_URI:append:sama5d2 = " file://encx24j600.patch"
+SRC_URI:append:sama5d2 = " file://0001-net-encx24j600-fix-transmit-queue-timeout-issue.patch"
 SRCREV = "7297efac896e4e51b9785918dde843674057d573"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 

--- a/recipes-kernel/linux/linux-mchp_6.6.23.bb
+++ b/recipes-kernel/linux/linux-mchp_6.6.23.bb
@@ -12,6 +12,8 @@ SRC_URI = "git://github.com/linux4microchip/linux.git;protocol=https;branch=${KB
 # kernel fragments
 SRC_URI:append:sama5      = " file://sama5.cfg"
 SRC_URI:append:sama5d2    = " file://greengrass.cfg"
+SRC_URI:append:sama5d2    = " file://encx24j600.patch"
+SRC_URI:append:sama5d2    = " file://0001-net-encx24j600-fix-transmit-queue-timeout-issue.patch"
 SRC_URI:append:\
 sama5d27-som1-ek-optee-sd = " file://sama5-linux-optee.cfg \
                               file://sama5d2/0001-dts-include-optee-dtsi.patch \


### PR DESCRIPTION
Related to #250

Add patches to fix the encx24j600 transmit queue timeout issue.

* **Kernel 5.15.68**
  - Add `encx24j600.patch` to `recipes-kernel/linux/linux-mchp_5.15.68.bb`.
  - Add `0001-net-encx24j600-fix-transmit-queue-timeout-issue.patch` to `recipes-kernel/linux/linux-mchp_5.15.68.bb`.
  - Add `encx24j600.patch` file to `recipes-kernel/linux/linux-mchp-5.15.68/sama5d2/`.

* **Kernel 6.1.55**
  - Add `encx24j600.patch` to `recipes-kernel/linux/linux-mchp_6.1.55.bb`.
  - Add `0001-net-encx24j600-fix-transmit-queue-timeout-issue.patch` to `recipes-kernel/linux/linux-mchp_6.1.55.bb`.
  - Add `encx24j600.patch` file to `recipes-kernel/linux/linux-mchp-6.1.55/sama5d2/`.

* **Kernel 6.6.23**
  - Add `encx24j600.patch` to `recipes-kernel/linux/linux-mchp_6.6.23.bb`.
  - Add `0001-net-encx24j600-fix-transmit-queue-timeout-issue.patch` to `recipes-kernel/linux/linux-mchp_6.6.23.bb`.
  - Add `encx24j600.patch` file to `recipes-kernel/linux/linux-mchp-6.6.23/sama5d2/`.

