### PR TITLE
Fix false positives in CVE check

### DIFF
--- a/recipes-security/cryptoauthlib/cryptoauthlib_3.7.7.bb
+++ b/recipes-security/cryptoauthlib/cryptoauthlib_3.7.7.bb
@@ -10,6 +10,7 @@ SRC_URI = "git://github.com/MicrochipTech/cryptoauthlib.git;branch=main;protocol
 
 PV = "1.0+git${SRCPV}"
 SRCREV = "caf67be64865a126c0cb23ac610213083baa6a60"
+CVE_VERSION = "20250213"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
The Yocto Scarthgap CVE checker flags the following as unresolved CVEs:
- CVE-2019-16128
- CVE-2019-16129

Provide the legacy CVE_VERSION so that these false positives don't show up.